### PR TITLE
add support for Windows platform in Copilot CLI path resolution

### DIFF
--- a/src/services/evaluator.ts
+++ b/src/services/evaluator.ts
@@ -224,6 +224,10 @@ async function loadConfig(configPath: string): Promise<EvalConfig> {
 }
 
 async function findCopilotCliPath(): Promise<string> {
+  if (process.platform === "win32") {
+    return "copilot";
+  }
+
   // Try standard PATH first
   try {
     const { stdout } = await execFileAsync("which", ["copilot"], { timeout: 5000 });

--- a/src/services/instructions.ts
+++ b/src/services/instructions.ts
@@ -90,6 +90,10 @@ Output ONLY the markdown content for the instructions file.`;
 const execFileAsync = promisify(execFile);
 
 async function findCopilotCliPath(): Promise<string> {
+  if (process.platform === "win32") {
+    return "copilot";
+  }
+
   // Try standard PATH first
   try {
     const { stdout } = await execFileAsync("which", ["copilot"], { timeout: 5000 });
@@ -121,6 +125,10 @@ async function findCopilotCliPath(): Promise<string> {
 
 async function assertCopilotCliReady(): Promise<string> {
   const cliPath = await findCopilotCliPath();
+  
+  if (process.platform === "win32" && cliPath === "copilot") {
+    return cliPath;
+  }
   
   try {
     await execFileAsync(cliPath, ["--version"], { timeout: 5000 });


### PR DESCRIPTION
## Add Windows support for Copilot CLI detection
 
### Problem
The Copilot CLI detection logic only worked on Unix/macOS systems. Windows users would get "Copilot CLI not found" errors even with Copilot installed.
 
### Solution
Added Windows support by returning `"copilot"` on Windows platforms and letting the Copilot SDK resolve it from PATH. This matches the pattern used in other working implementations.
 
Changes:
- `src/services/instructions.ts`: Added Windows check in `findCopilotCliPath()`
- `src/services/evaluator.ts`: Added Windows check in `findCopilotCliPath()`
 
### Implementation
```typescript
if (process.platform === "win32") {
  return "copilot";
}