### PR TITLE
Add .NET detection with console app and framework detection

### DIFF
--- a/src/services/analyzer.ts
+++ b/src/services/analyzer.ts
@@ -1,5 +1,6 @@
 import fs from "fs/promises";
 import path from "path";
+import fg from "fast-glob";
 import { isGitRepo } from "./git";
 
 export type RepoAnalysis = {
@@ -14,7 +15,8 @@ const PACKAGE_MANAGERS: Array<{ file: string; name: string }> = [
   { file: "pnpm-lock.yaml", name: "pnpm" },
   { file: "yarn.lock", name: "yarn" },
   { file: "package-lock.json", name: "npm" },
-  { file: "bun.lockb", name: "bun" }
+  { file: "bun.lockb", name: "bun" },
+  { file: "packages.lock.json", name: "nuget" }
 ];
 
 export async function analyzeRepo(repoPath: string): Promise<RepoAnalysis> {
@@ -32,12 +34,19 @@ export async function analyzeRepo(repoPath: string): Promise<RepoAnalysis> {
   const hasRequirements = files.includes("requirements.txt");
   const hasGoMod = files.includes("go.mod");
   const hasCargo = files.includes("Cargo.toml");
+  const hasDotnet = await hasDotnetSignalsDeep(repoPath, files);
 
   if (hasPackageJson) analysis.languages.push("JavaScript");
   if (hasTsConfig) analysis.languages.push("TypeScript");
   if (hasPyProject || hasRequirements) analysis.languages.push("Python");
   if (hasGoMod) analysis.languages.push("Go");
   if (hasCargo) analysis.languages.push("Rust");
+  if (hasDotnet.hasSignals) {
+    if (hasDotnet.hasCsProj) analysis.languages.push("C#");
+    if (hasDotnet.hasFsProj) analysis.languages.push("F#");
+    // Fallback to C# if we have signals but no specific project files (e.g., just .sln)
+    if (!hasDotnet.hasCsProj && !hasDotnet.hasFsProj) analysis.languages.push("C#");
+  }
 
   analysis.packageManager = await detectPackageManager(repoPath, files);
 
@@ -48,6 +57,12 @@ export async function analyzeRepo(repoPath: string): Promise<RepoAnalysis> {
       ...(packageJson?.devDependencies ?? {})
     });
     analysis.frameworks.push(...detectFrameworks(deps, files));
+  }
+
+  // Detect .NET frameworks from project files
+  if (hasDotnet.hasSignals) {
+    const dotnetFrameworks = await detectDotnetFrameworks(repoPath);
+    analysis.frameworks.push(...dotnetFrameworks);
   }
 
   analysis.languages = unique(analysis.languages);
@@ -63,6 +78,7 @@ async function detectPackageManager(repoPath: string, files: string[]): Promise<
 
   if (files.includes("package.json")) return "npm";
   if (files.includes("pyproject.toml")) return "pip";
+  if (hasDotnetSignals(files)) return "nuget";
   return undefined;
 }
 
@@ -101,4 +117,113 @@ async function readJson(filePath: string): Promise<Record<string, unknown> | und
 
 function unique<T>(items: T[]): T[] {
   return Array.from(new Set(items));
+}
+
+function hasDotnetSignals(files: string[]): boolean {
+  return files.some(
+    (file) =>
+      file.endsWith(".sln") ||
+      file.endsWith(".csproj") ||
+      file.endsWith(".fsproj") ||
+      file === "global.json" ||
+      file === "Directory.Build.props" ||
+      file === "packages.lock.json"
+  );
+}
+
+type DotnetSignals = {
+  hasSignals: boolean;
+  hasCsProj: boolean;
+  hasFsProj: boolean;
+};
+
+async function hasDotnetSignalsDeep(repoPath: string, files: string[]): Promise<DotnetSignals> {
+  // Check root files first (fast path)
+  const rootSignals = hasDotnetSignals(files);
+
+  // Glob for project files recursively
+  const csprojFiles = await fg("**/*.csproj", { cwd: repoPath, onlyFiles: true });
+  const fsprojFiles = await fg("**/*.fsproj", { cwd: repoPath, onlyFiles: true });
+
+  return {
+    hasSignals: rootSignals || csprojFiles.length > 0 || fsprojFiles.length > 0,
+    hasCsProj: csprojFiles.length > 0,
+    hasFsProj: fsprojFiles.length > 0
+  };
+}
+
+async function detectDotnetFrameworks(repoPath: string): Promise<string[]> {
+  const frameworks: string[] = [];
+
+  // Glob all project files recursively
+  const projectFiles = await fg("**/*.{csproj,fsproj}", { cwd: repoPath, onlyFiles: true });
+
+  for (const projFile of projectFiles) {
+    try {
+      const content = await fs.readFile(path.join(repoPath, projFile), "utf8");
+      const detected = parseDotnetProject(content);
+      frameworks.push(...detected);
+    } catch {
+      // Ignore read errors
+    }
+  }
+
+  return frameworks;
+}
+
+function parseDotnetProject(content: string): string[] {
+  const frameworks: string[] = [];
+
+  // Check SDK attribute for project type
+  if (content.includes('Sdk="Microsoft.NET.Sdk.Web"')) frameworks.push("ASP.NET Core");
+  if (content.includes('Sdk="Microsoft.NET.Sdk.BlazorWebAssembly"')) frameworks.push("Blazor WebAssembly");
+  if (content.includes('Sdk="Microsoft.NET.Sdk.Razor"')) frameworks.push("Razor");
+
+  // Check PackageReference includes
+  const hasPackage = (pkg: string): boolean => content.includes(`Include="${pkg}`);
+
+  // ASP.NET Core detection
+  if (hasPackage("Microsoft.AspNetCore") || hasPackage("Microsoft.AspNetCore.App")) {
+    frameworks.push("ASP.NET Core");
+  }
+
+  // Blazor detection
+  if (hasPackage("Microsoft.AspNetCore.Components")) frameworks.push("Blazor");
+
+  // Entity Framework detection
+  if (hasPackage("Microsoft.EntityFrameworkCore")) frameworks.push("Entity Framework");
+
+  // MAUI detection
+  if (hasPackage("Microsoft.Maui") || hasPackage("Microsoft.Maui.Controls")) {
+    frameworks.push(".NET MAUI");
+  }
+
+  // Xamarin detection
+  if (hasPackage("Xamarin.Forms") || hasPackage("Xamarin.Essentials") || hasPackage("Mono.Android")) {
+    frameworks.push("Xamarin");
+  }
+
+  // WPF detection
+  if (content.includes("<UseWPF>true</UseWPF>")) frameworks.push("WPF");
+
+  // WinForms detection
+  if (content.includes("<UseWindowsForms>true</UseWindowsForms>")) frameworks.push("Windows Forms");
+
+  // Test framework detection
+  if (hasPackage("xunit") || hasPackage("xunit.core")) frameworks.push("xUnit");
+  if (hasPackage("NUnit") || hasPackage("nunit.framework")) frameworks.push("NUnit");
+  if (hasPackage("MSTest.TestFramework") || hasPackage("Microsoft.NET.Test.Sdk")) {
+    frameworks.push("MSTest");
+  }
+
+  // Console app detection (only if no other specific framework detected)
+  if (frameworks.length === 0) {
+    const isExe = content.includes("<OutputType>Exe</OutputType>") || content.includes("<OutputType>WinExe</OutputType>");
+    const isStandardSdk = content.includes('Sdk="Microsoft.NET.Sdk"');
+    if (isExe && isStandardSdk) {
+      frameworks.push("Console");
+    }
+  }
+
+  return frameworks;
 }

--- a/src/services/instructions.ts
+++ b/src/services/instructions.ts
@@ -65,7 +65,7 @@ export async function generateCopilotInstructions(options: GenerateInstructionsO
 
 Use tools to explore:
 1. Check for existing instruction files: glob for **/{.github/copilot-instructions.md,AGENT.md,CLAUDE.md,.cursorrules,README.md}
-2. Identify the tech stack: look at package.json, tsconfig.json, pyproject.toml, Cargo.toml, etc.
+2. Identify the tech stack: look at package.json, tsconfig.json, pyproject.toml, Cargo.toml, .csproj, .fsproj, .sln, global.json, etc.
 3. Understand the structure: list key directories
 
 Generate concise instructions (~20-50 lines) covering:


### PR DESCRIPTION
This pull request enhances the repository analysis service to better detect .NET projects and their frameworks. It adds deep scanning for .NET project files (`.csproj`, `.fsproj`, `.sln`), recognizes NuGet as a package manager, and parses project files to identify specific .NET frameworks (like ASP.NET Core, Blazor, MAUI, etc.). Additionally, the tech stack identification instructions are updated to include .NET-related files.

**.NET and NuGet support:**
- Added detection for `.NET` project signals (e.g., `.csproj`, `.fsproj`, `.sln`, `global.json`, `packages.lock.json`) throughout the repository, not just in the root. This enables more accurate language and framework identification for C# and F# projects. [[1]](diffhunk://#diff-eaffdff597402a15e57142d5ee5d2ca71975dfe559878697a42daaf53c3537b5R37-R49) [[2]](diffhunk://#diff-eaffdff597402a15e57142d5ee5d2ca71975dfe559878697a42daaf53c3537b5R121-R229)
- Included `packages.lock.json` as a NuGet package manager indicator and updated package manager detection logic to recognize NuGet for .NET projects. [[1]](diffhunk://#diff-eaffdff597402a15e57142d5ee5d2ca71975dfe559878697a42daaf53c3537b5L17-R19) [[2]](diffhunk://#diff-eaffdff597402a15e57142d5ee5d2ca71975dfe559878697a42daaf53c3537b5R81)

**.NET framework detection:**
- Implemented recursive parsing of project files to detect frameworks such as ASP.NET Core, Blazor, Entity Framework, MAUI, Xamarin, WPF, Windows Forms, and common .NET test frameworks (xUnit, NUnit, MSTest). [[1]](diffhunk://#diff-eaffdff597402a15e57142d5ee5d2ca71975dfe559878697a42daaf53c3537b5R62-R67) [[2]](diffhunk://#diff-eaffdff597402a15e57142d5ee5d2ca71975dfe559878697a42daaf53c3537b5R121-R229)

**Tech stack identification improvements:**
- Updated copilot instruction generation to include .NET-specific files (`.csproj`, `.fsproj`, `.sln`, `global.json`) when identifying the tech stack.