### PR TITLE
feat: add skills generation command

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -19,6 +19,7 @@
 - **Analyzer:** Scans repo files to infer languages, frameworks, and package manager.
 - **Instructions:** Generates `.github/copilot-instructions.md` from convention files.
 - **Config Generation:** Writes `.vscode/settings.json` and `.vscode/mcp.json` (safe overwrite).
+- **Skills Generation:** Copies bundled meta-skills from `assets/skills/` to target repos.
 - **Git/GitHub:** Automates clone/branch/PR via `simple-git` and Octokit.
 - **Evaluation:** Compares agent responses with/without instructions using Copilot sessions.
 - **TUI:** `src/ui/tui.tsx` (Ink/React) for interactive terminal usage.
@@ -28,7 +29,7 @@
 - **Run locally (no build step):**
   - `npx tsx src/index.ts --help`
   - `npx tsx src/index.ts analyze [path] --json`
-  - `npx tsx src/index.ts generate mcp|vscode [path] [--force]`
+  - `npx tsx src/index.ts generate mcp|vscode|skills [path] [--force]`
   - `npx tsx src/index.ts instructions [--repo <path>] [--output <path>] [--model gpt-5]`
   - `npx tsx src/index.ts tui [--repo <path>]`
   - `npx tsx src/index.ts pr <owner/name> [--branch primer/add-configs]`
@@ -52,4 +53,6 @@
 - `.github/copilot-instructions.md` — This file
 - `src/index.ts` — CLI entrypoint
 - `src/services/` — Core logic
+- `src/services/skills.ts` — Skills generation service
+- `assets/skills/` — Bundled meta-skills (skill-creator, skill-planner, etc.)
 - `.vscode/settings.json` — Copilot/VS Code integration

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Primer is a CLI tool that analyzes your codebase and generates `.github/copilot-
 - **GitHub Integration** - Clone repos, create branches, and open PRs automatically
 - **Interactive TUI** - Beautiful terminal interface built with Ink
 - **Config Generation** - Generate MCP and VS Code configurations
+- **Skills Generation** - Add meta-skills for skill authoring (plan, create, evaluate, reskill)
 
 ## Prerequisites
 
@@ -122,14 +123,8 @@ npx tsx src/index.ts generate mcp
 # Generate VS Code settings
 npx tsx src/index.ts generate vscode --force
 
-# Generate custom prompts
-npx tsx src/index.ts generate prompts
-
-# Generate agent configs
-npx tsx src/index.ts generate agents
-
-# Generate .aiignore file
-npx tsx src/index.ts generate aiignore
+# Generate meta-skills for skill authoring
+npx tsx src/index.ts generate skills
 ```
 
 ### Manage Templates

--- a/assets/skills/artifacts/skills/plans/README.md
+++ b/assets/skills/artifacts/skills/plans/README.md
@@ -1,0 +1,45 @@
+# Skill Plans
+
+This directory contains planning documents for skills.
+
+## Directory Structure
+
+```
+plans/
+├── README.md                           # This file
+├── skills-status.md                    # Skill tracking and status
+└── <skill-name>-skill-planning.md      # Individual skill plans
+```
+
+## Plan Document Lifecycle
+
+```
+📝 Draft → ✅ Ready to Execute → 🚀 Executing → ✔️ Complete
+```
+
+| Status | Meaning | Next Action |
+|--------|---------|-------------|
+| 📝 Draft | Initial planning | Continue gathering requirements |
+| ✅ Ready to Execute | Plan approved | Run skill-creator to implement |
+| 🚀 Executing | Implementation in progress | Complete implementation |
+| ✔️ Complete | Fully implemented | Skill available for use |
+| ⏸️ On Hold | Paused | Waiting for dependency |
+| ⚠️ Superseded | Replaced | See replacement skill |
+
+## Creating a Plan
+
+1. Use `skill-planner`: "Use skill-planner to plan a skill for X"
+2. Document is created at `<skill-name>-skill-planning.md`
+3. Iterate on the plan with user feedback
+4. Run `skill-planner-eval` before proceeding
+
+## Plan Template
+
+See the skill-planner skill's `references/plan-template.md` for the standard template.
+
+## Conventions
+
+- One plan document per skill
+- Update status as you progress
+- Include exploration summary before designing
+- Get user confirmation before implementation

--- a/assets/skills/artifacts/skills/plans/code-reviewer-general-skill-planning.md
+++ b/assets/skills/artifacts/skills/plans/code-reviewer-general-skill-planning.md
@@ -1,0 +1,187 @@
+# Skill Planning: code-reviewer-general
+
+> **Status**: ✅ APPROVED  
+> **Created**: 2026-01-14  
+> **Author**: skill-planner (demo run)
+
+---
+
+## 1. Executive Summary
+
+**Goal**: Create a generic, repository-agnostic code review skill that can be immediately
+used in any repository and then tailored via `skill-reskilling`.
+
+**Key Decision**: This skill should be:
+- Generic enough to work out-of-box in any repo
+- Structured enough to provide consistent, high-signal reviews
+- Designed for reskilling (clear placeholders for repo-specific customization)
+
+---
+
+## 2. Exploration Summary
+
+### 2.1 Existing Skills Checked
+
+| Skill | Relevant? | Notes |
+|-------|-----------|-------|
+| `skill-reskilling` | ✅ Yes | Will be used to tailor this skill after adoption |
+| `skill-creator` | ✅ Yes | Used to implement this skill |
+| `skill-planner-eval` | ✅ Yes | Will evaluate this plan |
+
+### 2.2 External References
+
+- [GitHub awesome-copilot code-review-generic.instructions.md](https://github.com/github/awesome-copilot/blob/main/instructions/code-review-generic.instructions.md)
+  - Provides severity-based rubric (Critical/Important/Suggestion)
+  - Language-agnostic review priorities
+  - Checklist format for structured output
+
+### 2.3 Source Code Analysis
+
+Not applicable - this is a meta-skill that works across any codebase.
+
+### 2.4 Wiki/Documentation
+
+Not applicable - this skill is part of the starter kit, not a domain-specific skill.
+
+---
+
+## 3. Scope Definition
+
+### 3.1 In-Scope
+
+| Capability | Description |
+|------------|-------------|
+| Review uncommitted changes | `git diff` analysis |
+| Review branch vs base | `git diff base...HEAD` analysis |
+| Review PR (if tooling available) | PR diff analysis |
+| Severity-based findings | Critical/Important/Suggestion |
+| Checklist output | Structured, actionable feedback |
+| Risk assessment | Low/Medium/High risk rating |
+
+### 3.2 Out-of-Scope
+
+| Excluded | Reason |
+|----------|--------|
+| PR comment posting | Requires repo-specific PR tooling integration |
+| ADO/GitHub API calls | Not all repos have MCP configured |
+| Auto-fix generation | Separate concern; could be a future skill |
+| Test execution | Should be handled by CI or separate skill |
+
+### 3.3 Dependencies
+
+| Dependency | Type | Required? |
+|------------|------|-----------|
+| Git CLI | Tool | ✅ Yes |
+| skill-reskilling | Skill | Recommended (for tailoring) |
+
+---
+
+## 4. Skill Composition Decision
+
+**Decision**: Single skill with references
+
+**Rationale**:
+- Review logic is cohesive and fits in one SKILL.md
+- `references/review-guidelines.md` holds the rubric (easy to reskill)
+- No need to split or compose with other skills
+
+---
+
+## 5. Architecture (Not Applicable)
+
+This is a stateless review skill - no architecture diagrams needed.
+
+---
+
+## 6. Skill Structure
+
+```
+.github/skills/code-reviewer-general/
+├── SKILL.md                          # Main skill definition
+└── references/
+    └── review-guidelines.md          # Rubric and checklist (reskillable)
+```
+
+**Companion File**:
+```
+.github/instructions/code-review-generic.instructions.md
+```
+- Provides default review guidance for all Copilot CLI interactions
+- References upstream awesome-copilot template
+
+---
+
+## 7. User Interaction Patterns
+
+### 7.1 Primary Use Cases
+
+| Use Case | User Prompt | Skill Action |
+|----------|-------------|--------------|
+| Review local changes | "Review my uncommitted changes" | `git status` + `git diff` |
+| Review branch | "Review my branch vs main" | `git diff main...HEAD` |
+| Review PR | "Review PR #123" | Fetch PR diff (if tooling available) |
+
+### 7.2 Output Format
+
+1. **Summary** (2-5 bullets)
+2. **Risk Level**: Low / Medium / High
+3. **Findings** by severity:
+   - 🔴 Critical (block merge)
+   - 🟡 Important (discuss/should fix)
+   - 🟢 Suggestion (nice-to-have)
+4. **Tests & Validation**: what to run, what's missing
+
+---
+
+## 8. Reskilling Strategy
+
+After adoption, teams should immediately reskill this skill:
+
+```
+Reskill the code-reviewer-general skill for THIS repository. Find:
+- Standard build/test commands
+- Architecture hotspots and risk areas
+- Required quality gates
+- Team conventions
+Update SKILL.md and references/review-guidelines.md accordingly.
+```
+
+**Reskillable Sections**:
+- `references/review-guidelines.md` - Add repo-specific checks
+- `SKILL.md` description - Add repo-specific context
+- Test commands - Fill in actual build/test/lint commands
+
+---
+
+## 9. Success Criteria
+
+| Criterion | Measurement |
+|-----------|-------------|
+| Works out-of-box | Can review changes in any repo without configuration |
+| Provides structured output | Uses severity-based format consistently |
+| Easy to reskill | Clear placeholders, documented reskill process |
+| High-signal reviews | Focuses on security, correctness, tests, performance |
+
+---
+
+## 10. Implementation Checklist
+
+- [x] Create SKILL.md with frontmatter
+- [x] Create references/review-guidelines.md with rubric
+- [x] Create .github/instructions/code-review-generic.instructions.md
+- [x] Document reskill process in SKILL.md
+- [x] Update skills-status.md
+- [x] Plan evaluated by skill-planner-eval
+
+---
+
+## 11. Next Steps
+
+1. ✅ Plan approved (this document)
+2. ✅ Skill implemented by skill-creator
+3. ⏳ Teams adopt starter kit
+4. ⏳ Teams run reskilling to tailor for their repos
+
+---
+
+*This plan was generated by skill-planner to demonstrate the planning workflow.*

--- a/assets/skills/artifacts/skills/plans/skills-status.md
+++ b/assets/skills/artifacts/skills/plans/skills-status.md
@@ -1,0 +1,54 @@
+# Skills Status
+
+Track the status of all skills in this repository.
+
+## Active Skills
+
+| Skill | Status | Last Updated | Last Reskilled | Notes |
+|-------|--------|--------------|----------------|-------|
+| skill-planner | ✔️ Complete | {{DATE}} | - | Meta-skill for planning |
+| skill-creator | ✔️ Complete | {{DATE}} | - | Meta-skill for creating |
+| skill-planner-eval | ✔️ Complete | {{DATE}} | - | Meta-skill for plan evaluation |
+| skill-creator-eval | ✔️ Complete | {{DATE}} | - | Meta-skill for skill evaluation |
+| skill-reskilling | ✔️ Complete | {{DATE}} | - | Meta-skill for maintenance |
+| code-reviewer-general | 📝 Template | {{DATE}} | - | Run skill-reskilling after setup to tailor to your repo |
+
+## Planned Skills
+
+| Skill | Status | Plan Link | Target Date | Owner |
+|-------|--------|-----------|-------------|-------|
+| code-reviewer-general | ✅ Ready | [Plan](./code-reviewer-general-skill-planning.md) | 2026-01-14 | starter-kit |
+| {{your-skill}} | 📝 Draft | [Plan](./{{your-skill}}-skill-planning.md) | {{DATE}} | {{OWNER}} |
+
+## Skill Health
+
+### Reskilling Schedule
+
+| Skill | Last Reskill | Next Reskill | Priority |
+|-------|--------------|--------------|----------|
+| code-reviewer-general | Never | {{DATE}} | High |
+
+### Known Issues
+
+| Skill | Issue | Severity | Workaround |
+|-------|-------|----------|------------|
+| - | - | - | - |
+
+## Metrics
+
+- Total skills: 6 (5 meta + 1 template)
+- Default instructions: .github/instructions/code-review-generic.instructions.md
+- Domain skills: 0 (create your own!)
+- Last reskilling run: Never (recommended immediately after setup)
+
+## Status Legend
+
+| Status | Meaning |
+|--------|---------|
+| 📝 Draft | Planning in progress |
+| ✅ Ready | Plan approved, ready to implement |
+| 🚀 Executing | Implementation in progress |
+| ✔️ Complete | Fully implemented and tested |
+| ⏸️ On Hold | Temporarily paused |
+| ⚠️ Needs Reskill | Skill may need updates |
+| ❌ Deprecated | No longer maintained |

--- a/assets/skills/skill-creator-eval/SKILL.md
+++ b/assets/skills/skill-creator-eval/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: skill-creator-eval
+description: |
+  Evaluates an implemented skill package under .github/skills/<skill-name>/ for structure,
+  usability, safety, and conformance to its plan.
+  Use after skill-creator implementation and before merging/shipping.
+license: Complete terms in LICENSE.txt
+---
+
+<!-- Model provenance: Generated with a non-Opus 4.5 model/vendor (Copilot CLI session). -->
+
+# Skill Creator Eval
+
+## Purpose
+
+Evaluate an implemented skill directory (SKILL.md + scripts/references) and decide if it is ready to ship.
+
+## Inputs to Ask For
+
+- Skill directory path: `.github\skills\<skill-name>\`
+- Optional: the approved plan doc path
+- Any constraints (Windows-only, available tools)
+
+## Output
+
+Produce a structured report with:
+- Verdict: **Approve / Needs Changes / Blocked**
+- Checklist scorecard
+- Top issues (P0/P1/P2)
+- Concrete edits requested (file/section-level; line-level when easy)
+- Packaging/release risks
+
+Recommended file output:
+- `.wiki\Copilot\skills\plans\<skill-name>-skill-eval.md`
+
+## Workflow
+
+1. **Inventory**: list files; confirm `SKILL.md` exists and is the entry point.
+2. **Evaluate SKILL.md**: invocation, stepwise workflow, guardrails, CLI-friendly output.
+3. **Evaluate scripts (if any)**: parameters, safe defaults, error handling; no secrets.
+4. **Cross-check vs plan (if provided)**: missing promised artifacts; scope creep.
+5. **Write the evaluation report** (see `references\output-template.md`).
+
+## Notes
+
+- This repo may require `git add -f` for `.github` paths; flag if packaging looks wrong.
+

--- a/assets/skills/skill-creator-eval/references/output-template.md
+++ b/assets/skills/skill-creator-eval/references/output-template.md
@@ -1,0 +1,40 @@
+# Skill Implementation Evaluation Report (Template)
+
+## Inputs
+- Skill dir: `<path>`
+- Plan (optional): `<path>`
+- Constraints: `<...>`
+
+## Verdict
+**Approve / Needs Changes / Blocked**
+
+## Scorecard
+| Category | Pass? | Notes |
+|---|---|---|
+| Structure (Gate) |  |  |
+| Usability/UX (Gate) |  |  |
+| Safety/security (Gate) |  |  |
+| Platform correctness (Gate) |  |  |
+| Script quality |  |  |
+| Reference quality |  |  |
+| Plan conformance |  |  |
+| Maintainability |  |  |
+
+## Top Issues (Prioritized)
+### P0
+- 
+
+### P1
+- 
+
+### P2
+- 
+
+## Required Edits
+- 
+
+## Packaging / Release Risks
+- 
+
+## Notes
+- 

--- a/assets/skills/skill-creator-eval/references/rubric.md
+++ b/assets/skills/skill-creator-eval/references/rubric.md
@@ -1,0 +1,22 @@
+# skill-creator-eval rubric
+
+## Gates (fail any ⇒ Blocked)
+
+1. **Structure**: SKILL.md present; directory is coherent; no missing referenced files.
+2. **Usability/UX**: clear invocation + required inputs; stepwise workflow; concise outputs.
+3. **Safety/security**: no secrets; no destructive defaults; confirmations before privileged actions.
+4. **Platform correctness**: Windows/PowerShell friendly; uses Windows paths; avoids pagers.
+
+## Non-gate quality dimensions (score 0–2 each)
+
+- Script quality (parameterization, errors, deterministic behavior)
+- Reference quality (findable, not duplicated, not bloated)
+- Plan conformance (if plan provided)
+- Maintainability (clear separation; minimal redundancy)
+- Readability (clear structure, consistent headings, minimal fluff)
+
+## Severity guidance
+
+- **P0**: unsafe, non-functional, or unshippable
+- **P1**: major UX gaps or missing artifacts
+- **P2**: polish and improvements

--- a/assets/skills/skill-creator/LICENSE.txt
+++ b/assets/skills/skill-creator/LICENSE.txt
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/assets/skills/skill-creator/SKILL.md
+++ b/assets/skills/skill-creator/SKILL.md
@@ -1,0 +1,391 @@
+---
+name: skill-creator
+description: Guide for creating effective skills. This skill should be used when users want to create a new skill (or update an existing skill) that extends Claude's capabilities with specialized knowledge, workflows, or tool integrations.
+license: Complete terms in LICENSE.txt
+---
+
+<!-- 
+Attribution: This skill was adapted from https://github.com/anthropics/skills/tree/main/skills/skill-creator
+Original source: Anthropic Skills Repository
+-->
+
+# Skill Creator
+
+This skill provides guidance for creating effective skills.
+
+## About Skills
+
+Skills are modular, self-contained packages that extend Claude's capabilities by providing
+specialized knowledge, workflows, and tools. Think of them as "onboarding guides" for specific
+domains or tasks—they transform Claude from a general-purpose agent into a specialized agent
+equipped with procedural knowledge that no model can fully possess.
+
+### What Skills Provide
+
+1. Specialized workflows - Multi-step procedures for specific domains
+2. Tool integrations - Instructions for working with specific file formats or APIs
+3. Domain expertise - Company-specific knowledge, schemas, business logic
+4. Bundled resources - Scripts, references, and assets for complex and repetitive tasks
+
+## Core Principles
+
+### Concise is Key
+
+The context window is a public good. Skills share the context window with everything else Claude needs: system prompt, conversation history, other Skills' metadata, and the actual user request.
+
+**Default assumption: Claude is already very smart.** Only add context Claude doesn't already have. Challenge each piece of information: "Does Claude really need this explanation?" and "Does this paragraph justify its token cost?"
+
+Prefer concise examples over verbose explanations.
+
+### Set Appropriate Degrees of Freedom
+
+Match the level of specificity to the task's fragility and variability:
+
+**High freedom (text-based instructions)**: Use when multiple approaches are valid, decisions depend on context, or heuristics guide the approach.
+
+**Medium freedom (pseudocode or scripts with parameters)**: Use when a preferred pattern exists, some variation is acceptable, or configuration affects behavior.
+
+**Low freedom (specific scripts, few parameters)**: Use when operations are fragile and error-prone, consistency is critical, or a specific sequence must be followed.
+
+Think of Claude as exploring a path: a narrow bridge with cliffs needs specific guardrails (low freedom), while an open field allows many routes (high freedom).
+
+### Anatomy of a Skill
+
+Every skill consists of a required SKILL.md file and optional bundled resources:
+
+```
+skill-name/
+├── SKILL.md (required)
+│   ├── YAML frontmatter metadata (required)
+│   │   ├── name: (required)
+│   │   └── description: (required)
+│   └── Markdown instructions (required)
+└── Bundled Resources (optional)
+    ├── scripts/          - Executable code (Python/Bash/etc.)
+    ├── references/       - Documentation intended to be loaded into context as needed
+    └── assets/           - Files used in output (templates, icons, fonts, etc.)
+```
+
+#### SKILL.md (required)
+
+Every SKILL.md consists of:
+
+- **Frontmatter** (YAML): Contains `name` and `description` fields. These are the only fields that Claude reads to determine when the skill gets used, thus it is very important to be clear and comprehensive in describing what the skill is, and when it should be used.
+- **Body** (Markdown): Instructions and guidance for using the skill. Only loaded AFTER the skill triggers (if at all).
+
+#### Bundled Resources (optional)
+
+##### Scripts (`scripts/`)
+
+Executable code (Python/Bash/etc.) for tasks that require deterministic reliability or are repeatedly rewritten.
+
+- **When to include**: When the same code is being rewritten repeatedly or deterministic reliability is needed
+- **Example**: `scripts/rotate_pdf.py` for PDF rotation tasks
+- **Benefits**: Token efficient, deterministic, may be executed without loading into context
+- **Note**: Scripts may still need to be read by Claude for patching or environment-specific adjustments
+
+##### References (`references/`)
+
+Documentation and reference material intended to be loaded as needed into context to inform Claude's process and thinking.
+
+- **When to include**: For documentation that Claude should reference while working
+- **Examples**: `references/finance.md` for financial schemas, `references/mnda.md` for company NDA template, `references/policies.md` for company policies, `references/api_docs.md` for API specifications
+- **Use cases**: Database schemas, API documentation, domain knowledge, company policies, detailed workflow guides
+- **Benefits**: Keeps SKILL.md lean, loaded only when Claude determines it's needed
+- **Best practice**: If files are large (>10k words), include grep search patterns in SKILL.md
+- **Avoid duplication**: Information should live in either SKILL.md or references files, not both. Prefer references files for detailed information unless it's truly core to the skill—this keeps SKILL.md lean while making information discoverable without hogging the context window. Keep only essential procedural instructions and workflow guidance in SKILL.md; move detailed reference material, schemas, and examples to references files.
+
+##### Assets (`assets/`)
+
+Files not intended to be loaded into context, but rather used within the output Claude produces.
+
+- **When to include**: When the skill needs files that will be used in the final output
+- **Examples**: `assets/logo.png` for brand assets, `assets/slides.pptx` for PowerPoint templates, `assets/frontend-template/` for HTML/React boilerplate, `assets/font.ttf` for typography
+- **Use cases**: Templates, images, icons, boilerplate code, fonts, sample documents that get copied or modified
+- **Benefits**: Separates output resources from documentation, enables Claude to use files without loading them into context
+
+#### What to Not Include in a Skill
+
+A skill should only contain essential files that directly support its functionality. Do NOT create extraneous documentation or auxiliary files, including:
+
+- README.md
+- INSTALLATION_GUIDE.md
+- QUICK_REFERENCE.md
+- CHANGELOG.md
+- etc.
+
+The skill should only contain the information needed for an AI agent to do the job at hand. It should not contain auxilary context about the process that went into creating it, setup and testing procedures, user-facing documentation, etc. Creating additional documentation files just adds clutter and confusion.
+
+### Progressive Disclosure Design Principle
+
+Skills use a three-level loading system to manage context efficiently:
+
+1. **Metadata (name + description)** - Always in context (~100 words)
+2. **SKILL.md body** - When skill triggers (<5k words)
+3. **Bundled resources** - As needed by Claude (Unlimited because scripts can be executed without reading into context window)
+
+#### Progressive Disclosure Patterns
+
+Keep SKILL.md body to the essentials and under 500 lines to minimize context bloat. Split content into separate files when approaching this limit. When splitting out content into other files, it is very important to reference them from SKILL.md and describe clearly when to read them, to ensure the reader of the skill knows they exist and when to use them.
+
+**Key principle:** When a skill supports multiple variations, frameworks, or options, keep only the core workflow and selection guidance in SKILL.md. Move variant-specific details (patterns, examples, configuration) into separate reference files.
+
+**Pattern 1: High-level guide with references**
+
+```markdown
+# PDF Processing
+
+## Quick start
+
+Extract text with pdfplumber:
+[code example]
+
+## Advanced features
+
+- **Form filling**: See [FORMS.md](FORMS.md) for complete guide
+- **API reference**: See [REFERENCE.md](REFERENCE.md) for all methods
+- **Examples**: See [EXAMPLES.md](EXAMPLES.md) for common patterns
+```
+
+Claude loads FORMS.md, REFERENCE.md, or EXAMPLES.md only when needed.
+
+**Pattern 2: Domain-specific organization**
+
+For Skills with multiple domains, organize content by domain to avoid loading irrelevant context:
+
+```
+bigquery-skill/
+├── SKILL.md (overview and navigation)
+└── reference/
+    ├── finance.md (revenue, billing metrics)
+    ├── sales.md (opportunities, pipeline)
+    ├── product.md (API usage, features)
+    └── marketing.md (campaigns, attribution)
+```
+
+When a user asks about sales metrics, Claude only reads sales.md.
+
+Similarly, for skills supporting multiple frameworks or variants, organize by variant:
+
+```
+cloud-deploy/
+├── SKILL.md (workflow + provider selection)
+└── references/
+    ├── aws.md (AWS deployment patterns)
+    ├── gcp.md (GCP deployment patterns)
+    └── azure.md (Azure deployment patterns)
+```
+
+When the user chooses AWS, Claude only reads aws.md.
+
+**Pattern 3: Conditional details**
+
+Show basic content, link to advanced content:
+
+```markdown
+# DOCX Processing
+
+## Creating documents
+
+Use docx-js for new documents. See [DOCX-JS.md](DOCX-JS.md).
+
+## Editing documents
+
+For simple edits, modify the XML directly.
+
+**For tracked changes**: See [REDLINING.md](REDLINING.md)
+**For OOXML details**: See [OOXML.md](OOXML.md)
+```
+
+Claude reads REDLINING.md or OOXML.md only when the user needs those features.
+
+**Important guidelines:**
+
+- **Avoid deeply nested references** - Keep references one level deep from SKILL.md. All reference files should link directly from SKILL.md.
+- **Structure longer reference files** - For files longer than 100 lines, include a table of contents at the top so Claude can see the full scope when previewing.
+
+## Skill Creation Process
+
+**IMPORTANT: Always start in planning mode.** Before creating any files, explore the codebase, gather requirements, and create a plan document. Get user confirmation before proceeding to implementation.
+
+Skill creation involves these steps:
+
+1. **Explore and understand** the skill with concrete examples
+2. **Create a plan document** and confirm with user before proceeding
+3. **Evaluate the plan** with `skill-planner-eval` before implementation
+4. Plan reusable skill contents (scripts, references, assets)
+5. Initialize the skill (run init_skill.py)
+6. Edit the skill (implement resources and write SKILL.md)
+7. Package the skill (run package_skill.py)
+8. **Evaluate the implemented skill** with `skill-creator-eval` before shipping
+9. Iterate based on real usage
+
+Follow these steps in order, skipping only if there is a clear reason why they are not applicable.
+
+### Step 0: Planning Mode (Required)
+
+Before creating any skill, always start in planning mode:
+
+1. **Explore the codebase** to understand existing patterns, documentation, and conventions
+2. **Ask clarifying questions** to understand the skill's purpose and scope
+3. **Create a plan document** in `artifacts/skills/plans/<skill-name>-planning.md` with:
+   - Problem statement
+   - Proposed solution
+   - Directory structure
+   - File list with descriptions
+   - Implementation checklist
+   - Status tracking
+4. **Present the plan to the user** and ask for confirmation before proceeding
+5. **Only after user approval**, continue to Step 1
+
+This planning-first approach:
+- Catches misunderstandings before code is written
+- Allows iteration on the plan (cheaper than iterating on implementation)
+- Creates documentation for future reference
+- Aligns with Anthropic's recommended "Explore → Plan → Code → Commit" workflow
+
+See `artifacts/skills/plans/README.md` for plan document structure and best practices.
+
+### Step 1: Understanding the Skill with Concrete Examples
+
+Skip this step only when the skill's usage patterns are already clearly understood. It remains valuable even when working with an existing skill.
+
+To create an effective skill, clearly understand concrete examples of how the skill will be used. This understanding can come from either direct user examples or generated examples that are validated with user feedback.
+
+For example, when building an image-editor skill, relevant questions include:
+
+- "What functionality should the image-editor skill support? Editing, rotating, anything else?"
+- "Can you give some examples of how this skill would be used?"
+- "I can imagine users asking for things like 'Remove the red-eye from this image' or 'Rotate this image'. Are there other ways you imagine this skill being used?"
+- "What would a user say that should trigger this skill?"
+
+To avoid overwhelming users, avoid asking too many questions in a single message. Start with the most important questions and follow up as needed for better effectiveness.
+
+Conclude this step when there is a clear sense of the functionality the skill should support.
+
+### Step 2: Planning the Reusable Skill Contents
+
+To turn concrete examples into an effective skill, analyze each example by:
+
+1. Considering how to execute on the example from scratch
+2. Identifying what scripts, references, and assets would be helpful when executing these workflows repeatedly
+
+Example: When building a `pdf-editor` skill to handle queries like "Help me rotate this PDF," the analysis shows:
+
+1. Rotating a PDF requires re-writing the same code each time
+2. A `scripts/rotate_pdf.py` script would be helpful to store in the skill
+
+Example: When designing a `frontend-webapp-builder` skill for queries like "Build me a todo app" or "Build me a dashboard to track my steps," the analysis shows:
+
+1. Writing a frontend webapp requires the same boilerplate HTML/React each time
+2. An `assets/hello-world/` template containing the boilerplate HTML/React project files would be helpful to store in the skill
+
+Example: When building a `big-query` skill to handle queries like "How many users have logged in today?" the analysis shows:
+
+1. Querying BigQuery requires re-discovering the table schemas and relationships each time
+2. A `references/schema.md` file documenting the table schemas would be helpful to store in the skill
+
+To establish the skill's contents, analyze each concrete example to create a list of the reusable resources to include: scripts, references, and assets.
+
+### Step 3: Initializing the Skill
+
+At this point, it is time to actually create the skill.
+
+Skip this step only if the skill being developed already exists, and iteration or packaging is needed. In this case, continue to the next step.
+
+When creating a new skill from scratch, always run the `init_skill.py` script. The script conveniently generates a new template skill directory that automatically includes everything a skill requires, making the skill creation process much more efficient and reliable.
+
+Usage:
+
+```bash
+scripts/init_skill.py <skill-name> --path <output-directory>
+```
+
+The script:
+
+- Creates the skill directory at the specified path
+- Generates a SKILL.md template with proper frontmatter and TODO placeholders
+- Creates example resource directories: `scripts/`, `references/`, and `assets/`
+- Adds example files in each directory that can be customized or deleted
+
+After initialization, customize or remove the generated SKILL.md and example files as needed.
+
+### Step 4: Edit the Skill
+
+When editing the (newly-generated or existing) skill, remember that the skill is being created for another instance of Claude to use. Include information that would be beneficial and non-obvious to Claude. Consider what procedural knowledge, domain-specific details, or reusable assets would help another Claude instance execute these tasks more effectively.
+
+#### Learn Proven Design Patterns
+
+Consult these helpful guides based on your skill's needs:
+
+- **Multi-step processes**: See references/workflows.md for sequential workflows and conditional logic
+- **Specific output formats or quality standards**: See references/output-patterns.md for template and example patterns
+
+These files contain established best practices for effective skill design.
+
+#### Start with Reusable Skill Contents
+
+To begin implementation, start with the reusable resources identified above: `scripts/`, `references/`, and `assets/` files. Note that this step may require user input. For example, when implementing a `brand-guidelines` skill, the user may need to provide brand assets or templates to store in `assets/`, or documentation to store in `references/`.
+
+Added scripts must be tested by actually running them to ensure there are no bugs and that the output matches what is expected. If there are many similar scripts, only a representative sample needs to be tested to ensure confidence that they all work while balancing time to completion.
+
+Any example files and directories not needed for the skill should be deleted. The initialization script creates example files in `scripts/`, `references/`, and `assets/` to demonstrate structure, but most skills won't need all of them.
+
+#### Update SKILL.md
+
+**Writing Guidelines:** Always use imperative/infinitive form.
+
+##### Frontmatter
+
+Write the YAML frontmatter with `name` and `description`:
+
+- `name`: The skill name
+- `description`: This is the primary triggering mechanism for your skill, and helps Claude understand when to use the skill.
+  - Include both what the Skill does and specific triggers/contexts for when to use it.
+  - Include all "when to use" information here - Not in the body. The body is only loaded after triggering, so "When to Use This Skill" sections in the body are not helpful to Claude.
+  - Example description for a `docx` skill: "Comprehensive document creation, editing, and analysis with support for tracked changes, comments, formatting preservation, and text extraction. Use when Claude needs to work with professional documents (.docx files) for: (1) Creating new documents, (2) Modifying or editing content, (3) Working with tracked changes, (4) Adding comments, or any other document tasks"
+
+Do not include any other fields in YAML frontmatter.
+
+##### Body
+
+Write instructions for using the skill and its bundled resources.
+
+### Step 5: Packaging a Skill
+
+Once development of the skill is complete, it must be packaged into a distributable .skill file that gets shared with the user. The packaging process automatically validates the skill first to ensure it meets all requirements:
+
+```bash
+scripts/package_skill.py <path/to/skill-folder>
+```
+
+Optional output directory specification:
+
+```bash
+scripts/package_skill.py <path/to/skill-folder> ./dist
+```
+
+The packaging script will:
+
+1. **Validate** the skill automatically, checking:
+
+   - YAML frontmatter format and required fields
+   - Skill naming conventions and directory structure
+   - Description completeness and quality
+   - File organization and resource references
+
+2. **Package** the skill if validation passes, creating a .skill file named after the skill (e.g., `my-skill.skill`) that includes all files and maintains the proper directory structure for distribution. The .skill file is a zip file with a .skill extension.
+
+If validation fails, the script will report the errors and exit without creating a package. Fix any validation errors and run the packaging command again.
+
+### Step 6: Iterate
+
+After testing the skill, users may request improvements. Often this happens right after using the skill, with fresh context of how the skill performed.
+
+**Iteration workflow:**
+
+1. Use the skill on real tasks
+2. Notice struggles or inefficiencies
+3. Identify how SKILL.md or bundled resources should be updated
+4. Implement changes and test again
+

--- a/assets/skills/skill-creator/references/output-patterns.md
+++ b/assets/skills/skill-creator/references/output-patterns.md
@@ -1,0 +1,82 @@
+# Output Patterns
+
+Use these patterns when skills need to produce consistent, high-quality output.
+
+## Template Pattern
+
+Provide templates for output format. Match the level of strictness to your needs.
+
+**For strict requirements (like API responses or data formats):**
+
+```markdown
+## Report structure
+
+ALWAYS use this exact template structure:
+
+# [Analysis Title]
+
+## Executive summary
+[One-paragraph overview of key findings]
+
+## Key findings
+- Finding 1 with supporting data
+- Finding 2 with supporting data
+- Finding 3 with supporting data
+
+## Recommendations
+1. Specific actionable recommendation
+2. Specific actionable recommendation
+```
+
+**For flexible guidance (when adaptation is useful):**
+
+```markdown
+## Report structure
+
+Here is a sensible default format, but use your best judgment:
+
+# [Analysis Title]
+
+## Executive summary
+[Overview]
+
+## Key findings
+[Adapt sections based on what you discover]
+
+## Recommendations
+[Tailor to the specific context]
+
+Adjust sections as needed for the specific analysis type.
+```
+
+## Examples Pattern
+
+For skills where output quality depends on seeing examples, provide input/output pairs:
+
+```markdown
+## Commit message format
+
+Generate commit messages following these examples:
+
+**Example 1:**
+Input: Added user authentication with JWT tokens
+Output:
+```
+feat(auth): implement JWT-based authentication
+
+Add login endpoint and token validation middleware
+```
+
+**Example 2:**
+Input: Fixed bug where dates displayed incorrectly in reports
+Output:
+```
+fix(reports): correct date formatting in timezone conversion
+
+Use UTC timestamps consistently across report generation
+```
+
+Follow this style: type(scope): brief description, then detailed explanation.
+```
+
+Examples help Claude understand the desired style and level of detail more clearly than descriptions alone.

--- a/assets/skills/skill-creator/references/workflows.md
+++ b/assets/skills/skill-creator/references/workflows.md
@@ -1,0 +1,28 @@
+# Workflow Patterns
+
+## Sequential Workflows
+
+For complex tasks, break operations into clear, sequential steps. It is often helpful to give Claude an overview of the process towards the beginning of SKILL.md:
+
+```markdown
+Filling a PDF form involves these steps:
+
+1. Analyze the form (run analyze_form.py)
+2. Create field mapping (edit fields.json)
+3. Validate mapping (run validate_fields.py)
+4. Fill the form (run fill_form.py)
+5. Verify output (run verify_output.py)
+```
+
+## Conditional Workflows
+
+For tasks with branching logic, guide Claude through decision points:
+
+```markdown
+1. Determine the modification type:
+   **Creating new content?** → Follow "Creation workflow" below
+   **Editing existing content?** → Follow "Editing workflow" below
+
+2. Creation workflow: [steps]
+3. Editing workflow: [steps]
+```

--- a/assets/skills/skill-creator/scripts/init_skill.py
+++ b/assets/skills/skill-creator/scripts/init_skill.py
@@ -1,0 +1,303 @@
+#!/usr/bin/env python3
+"""
+Skill Initializer - Creates a new skill from template
+
+Usage:
+    init_skill.py <skill-name> --path <path>
+
+Examples:
+    init_skill.py my-new-skill --path skills/public
+    init_skill.py my-api-helper --path skills/private
+    init_skill.py custom-skill --path /custom/location
+"""
+
+import sys
+from pathlib import Path
+
+
+SKILL_TEMPLATE = """---
+name: {skill_name}
+description: [TODO: Complete and informative explanation of what the skill does and when to use it. Include WHEN to use this skill - specific scenarios, file types, or tasks that trigger it.]
+---
+
+# {skill_title}
+
+## Overview
+
+[TODO: 1-2 sentences explaining what this skill enables]
+
+## Structuring This Skill
+
+[TODO: Choose the structure that best fits this skill's purpose. Common patterns:
+
+**1. Workflow-Based** (best for sequential processes)
+- Works well when there are clear step-by-step procedures
+- Example: DOCX skill with "Workflow Decision Tree" → "Reading" → "Creating" → "Editing"
+- Structure: ## Overview → ## Workflow Decision Tree → ## Step 1 → ## Step 2...
+
+**2. Task-Based** (best for tool collections)
+- Works well when the skill offers different operations/capabilities
+- Example: PDF skill with "Quick Start" → "Merge PDFs" → "Split PDFs" → "Extract Text"
+- Structure: ## Overview → ## Quick Start → ## Task Category 1 → ## Task Category 2...
+
+**3. Reference/Guidelines** (best for standards or specifications)
+- Works well for brand guidelines, coding standards, or requirements
+- Example: Brand styling with "Brand Guidelines" → "Colors" → "Typography" → "Features"
+- Structure: ## Overview → ## Guidelines → ## Specifications → ## Usage...
+
+**4. Capabilities-Based** (best for integrated systems)
+- Works well when the skill provides multiple interrelated features
+- Example: Product Management with "Core Capabilities" → numbered capability list
+- Structure: ## Overview → ## Core Capabilities → ### 1. Feature → ### 2. Feature...
+
+Patterns can be mixed and matched as needed. Most skills combine patterns (e.g., start with task-based, add workflow for complex operations).
+
+Delete this entire "Structuring This Skill" section when done - it's just guidance.]
+
+## [TODO: Replace with the first main section based on chosen structure]
+
+[TODO: Add content here. See examples in existing skills:
+- Code samples for technical skills
+- Decision trees for complex workflows
+- Concrete examples with realistic user requests
+- References to scripts/templates/references as needed]
+
+## Resources
+
+This skill includes example resource directories that demonstrate how to organize different types of bundled resources:
+
+### scripts/
+Executable code (Python/Bash/etc.) that can be run directly to perform specific operations.
+
+**Examples from other skills:**
+- PDF skill: `fill_fillable_fields.py`, `extract_form_field_info.py` - utilities for PDF manipulation
+- DOCX skill: `document.py`, `utilities.py` - Python modules for document processing
+
+**Appropriate for:** Python scripts, shell scripts, or any executable code that performs automation, data processing, or specific operations.
+
+**Note:** Scripts may be executed without loading into context, but can still be read by Claude for patching or environment adjustments.
+
+### references/
+Documentation and reference material intended to be loaded into context to inform Claude's process and thinking.
+
+**Examples from other skills:**
+- Product management: `communication.md`, `context_building.md` - detailed workflow guides
+- BigQuery: API reference documentation and query examples
+- Finance: Schema documentation, company policies
+
+**Appropriate for:** In-depth documentation, API references, database schemas, comprehensive guides, or any detailed information that Claude should reference while working.
+
+### assets/
+Files not intended to be loaded into context, but rather used within the output Claude produces.
+
+**Examples from other skills:**
+- Brand styling: PowerPoint template files (.pptx), logo files
+- Frontend builder: HTML/React boilerplate project directories
+- Typography: Font files (.ttf, .woff2)
+
+**Appropriate for:** Templates, boilerplate code, document templates, images, icons, fonts, or any files meant to be copied or used in the final output.
+
+---
+
+**Any unneeded directories can be deleted.** Not every skill requires all three types of resources.
+"""
+
+EXAMPLE_SCRIPT = '''#!/usr/bin/env python3
+"""
+Example helper script for {skill_name}
+
+This is a placeholder script that can be executed directly.
+Replace with actual implementation or delete if not needed.
+
+Example real scripts from other skills:
+- pdf/scripts/fill_fillable_fields.py - Fills PDF form fields
+- pdf/scripts/convert_pdf_to_images.py - Converts PDF pages to images
+"""
+
+def main():
+    print("This is an example script for {skill_name}")
+    # TODO: Add actual script logic here
+    # This could be data processing, file conversion, API calls, etc.
+
+if __name__ == "__main__":
+    main()
+'''
+
+EXAMPLE_REFERENCE = """# Reference Documentation for {skill_title}
+
+This is a placeholder for detailed reference documentation.
+Replace with actual reference content or delete if not needed.
+
+Example real reference docs from other skills:
+- product-management/references/communication.md - Comprehensive guide for status updates
+- product-management/references/context_building.md - Deep-dive on gathering context
+- bigquery/references/ - API references and query examples
+
+## When Reference Docs Are Useful
+
+Reference docs are ideal for:
+- Comprehensive API documentation
+- Detailed workflow guides
+- Complex multi-step processes
+- Information too lengthy for main SKILL.md
+- Content that's only needed for specific use cases
+
+## Structure Suggestions
+
+### API Reference Example
+- Overview
+- Authentication
+- Endpoints with examples
+- Error codes
+- Rate limits
+
+### Workflow Guide Example
+- Prerequisites
+- Step-by-step instructions
+- Common patterns
+- Troubleshooting
+- Best practices
+"""
+
+EXAMPLE_ASSET = """# Example Asset File
+
+This placeholder represents where asset files would be stored.
+Replace with actual asset files (templates, images, fonts, etc.) or delete if not needed.
+
+Asset files are NOT intended to be loaded into context, but rather used within
+the output Claude produces.
+
+Example asset files from other skills:
+- Brand guidelines: logo.png, slides_template.pptx
+- Frontend builder: hello-world/ directory with HTML/React boilerplate
+- Typography: custom-font.ttf, font-family.woff2
+- Data: sample_data.csv, test_dataset.json
+
+## Common Asset Types
+
+- Templates: .pptx, .docx, boilerplate directories
+- Images: .png, .jpg, .svg, .gif
+- Fonts: .ttf, .otf, .woff, .woff2
+- Boilerplate code: Project directories, starter files
+- Icons: .ico, .svg
+- Data files: .csv, .json, .xml, .yaml
+
+Note: This is a text placeholder. Actual assets can be any file type.
+"""
+
+
+def title_case_skill_name(skill_name):
+    """Convert hyphenated skill name to Title Case for display."""
+    return ' '.join(word.capitalize() for word in skill_name.split('-'))
+
+
+def init_skill(skill_name, path):
+    """
+    Initialize a new skill directory with template SKILL.md.
+
+    Args:
+        skill_name: Name of the skill
+        path: Path where the skill directory should be created
+
+    Returns:
+        Path to created skill directory, or None if error
+    """
+    # Determine skill directory path
+    skill_dir = Path(path).resolve() / skill_name
+
+    # Check if directory already exists
+    if skill_dir.exists():
+        print(f"❌ Error: Skill directory already exists: {skill_dir}")
+        return None
+
+    # Create skill directory
+    try:
+        skill_dir.mkdir(parents=True, exist_ok=False)
+        print(f"✅ Created skill directory: {skill_dir}")
+    except Exception as e:
+        print(f"❌ Error creating directory: {e}")
+        return None
+
+    # Create SKILL.md from template
+    skill_title = title_case_skill_name(skill_name)
+    skill_content = SKILL_TEMPLATE.format(
+        skill_name=skill_name,
+        skill_title=skill_title
+    )
+
+    skill_md_path = skill_dir / 'SKILL.md'
+    try:
+        skill_md_path.write_text(skill_content)
+        print("✅ Created SKILL.md")
+    except Exception as e:
+        print(f"❌ Error creating SKILL.md: {e}")
+        return None
+
+    # Create resource directories with example files
+    try:
+        # Create scripts/ directory with example script
+        scripts_dir = skill_dir / 'scripts'
+        scripts_dir.mkdir(exist_ok=True)
+        example_script = scripts_dir / 'example.py'
+        example_script.write_text(EXAMPLE_SCRIPT.format(skill_name=skill_name))
+        example_script.chmod(0o755)
+        print("✅ Created scripts/example.py")
+
+        # Create references/ directory with example reference doc
+        references_dir = skill_dir / 'references'
+        references_dir.mkdir(exist_ok=True)
+        example_reference = references_dir / 'api_reference.md'
+        example_reference.write_text(EXAMPLE_REFERENCE.format(skill_title=skill_title))
+        print("✅ Created references/api_reference.md")
+
+        # Create assets/ directory with example asset placeholder
+        assets_dir = skill_dir / 'assets'
+        assets_dir.mkdir(exist_ok=True)
+        example_asset = assets_dir / 'example_asset.txt'
+        example_asset.write_text(EXAMPLE_ASSET)
+        print("✅ Created assets/example_asset.txt")
+    except Exception as e:
+        print(f"❌ Error creating resource directories: {e}")
+        return None
+
+    # Print next steps
+    print(f"\n✅ Skill '{skill_name}' initialized successfully at {skill_dir}")
+    print("\nNext steps:")
+    print("1. Edit SKILL.md to complete the TODO items and update the description")
+    print("2. Customize or delete the example files in scripts/, references/, and assets/")
+    print("3. Run the validator when ready to check the skill structure")
+
+    return skill_dir
+
+
+def main():
+    if len(sys.argv) < 4 or sys.argv[2] != '--path':
+        print("Usage: init_skill.py <skill-name> --path <path>")
+        print("\nSkill name requirements:")
+        print("  - Hyphen-case identifier (e.g., 'data-analyzer')")
+        print("  - Lowercase letters, digits, and hyphens only")
+        print("  - Max 40 characters")
+        print("  - Must match directory name exactly")
+        print("\nExamples:")
+        print("  init_skill.py my-new-skill --path skills/public")
+        print("  init_skill.py my-api-helper --path skills/private")
+        print("  init_skill.py custom-skill --path /custom/location")
+        sys.exit(1)
+
+    skill_name = sys.argv[1]
+    path = sys.argv[3]
+
+    print(f"🚀 Initializing skill: {skill_name}")
+    print(f"   Location: {path}")
+    print()
+
+    result = init_skill(skill_name, path)
+
+    if result:
+        sys.exit(0)
+    else:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/assets/skills/skill-creator/scripts/package_skill.py
+++ b/assets/skills/skill-creator/scripts/package_skill.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""
+Skill Packager - Creates a distributable .skill file of a skill folder
+
+Usage:
+    python utils/package_skill.py <path/to/skill-folder> [output-directory]
+
+Example:
+    python utils/package_skill.py skills/public/my-skill
+    python utils/package_skill.py skills/public/my-skill ./dist
+"""
+
+import sys
+import zipfile
+from pathlib import Path
+from quick_validate import validate_skill
+
+
+def package_skill(skill_path, output_dir=None):
+    """
+    Package a skill folder into a .skill file.
+
+    Args:
+        skill_path: Path to the skill folder
+        output_dir: Optional output directory for the .skill file (defaults to current directory)
+
+    Returns:
+        Path to the created .skill file, or None if error
+    """
+    skill_path = Path(skill_path).resolve()
+
+    # Validate skill folder exists
+    if not skill_path.exists():
+        print(f"❌ Error: Skill folder not found: {skill_path}")
+        return None
+
+    if not skill_path.is_dir():
+        print(f"❌ Error: Path is not a directory: {skill_path}")
+        return None
+
+    # Validate SKILL.md exists
+    skill_md = skill_path / "SKILL.md"
+    if not skill_md.exists():
+        print(f"❌ Error: SKILL.md not found in {skill_path}")
+        return None
+
+    # Run validation before packaging
+    print("🔍 Validating skill...")
+    valid, message = validate_skill(skill_path)
+    if not valid:
+        print(f"❌ Validation failed: {message}")
+        print("   Please fix the validation errors before packaging.")
+        return None
+    print(f"✅ {message}\n")
+
+    # Determine output location
+    skill_name = skill_path.name
+    if output_dir:
+        output_path = Path(output_dir).resolve()
+        output_path.mkdir(parents=True, exist_ok=True)
+    else:
+        output_path = Path.cwd()
+
+    skill_filename = output_path / f"{skill_name}.skill"
+
+    # Create the .skill file (zip format)
+    try:
+        with zipfile.ZipFile(skill_filename, 'w', zipfile.ZIP_DEFLATED) as zipf:
+            # Walk through the skill directory
+            for file_path in skill_path.rglob('*'):
+                if file_path.is_file():
+                    # Calculate the relative path within the zip
+                    arcname = file_path.relative_to(skill_path.parent)
+                    zipf.write(file_path, arcname)
+                    print(f"  Added: {arcname}")
+
+        print(f"\n✅ Successfully packaged skill to: {skill_filename}")
+        return skill_filename
+
+    except Exception as e:
+        print(f"❌ Error creating .skill file: {e}")
+        return None
+
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: python utils/package_skill.py <path/to/skill-folder> [output-directory]")
+        print("\nExample:")
+        print("  python utils/package_skill.py skills/public/my-skill")
+        print("  python utils/package_skill.py skills/public/my-skill ./dist")
+        sys.exit(1)
+
+    skill_path = sys.argv[1]
+    output_dir = sys.argv[2] if len(sys.argv) > 2 else None
+
+    print(f"📦 Packaging skill: {skill_path}")
+    if output_dir:
+        print(f"   Output directory: {output_dir}")
+    print()
+
+    result = package_skill(skill_path, output_dir)
+
+    if result:
+        sys.exit(0)
+    else:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/assets/skills/skill-creator/scripts/quick_validate.py
+++ b/assets/skills/skill-creator/scripts/quick_validate.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""
+Quick validation script for skills - minimal version
+"""
+
+import sys
+import os
+import re
+import yaml
+from pathlib import Path
+
+def validate_skill(skill_path):
+    """Basic validation of a skill"""
+    skill_path = Path(skill_path)
+
+    # Check SKILL.md exists
+    skill_md = skill_path / 'SKILL.md'
+    if not skill_md.exists():
+        return False, "SKILL.md not found"
+
+    # Read and validate frontmatter
+    content = skill_md.read_text()
+    if not content.startswith('---'):
+        return False, "No YAML frontmatter found"
+
+    # Extract frontmatter
+    match = re.match(r'^---\n(.*?)\n---', content, re.DOTALL)
+    if not match:
+        return False, "Invalid frontmatter format"
+
+    frontmatter_text = match.group(1)
+
+    # Parse YAML frontmatter
+    try:
+        frontmatter = yaml.safe_load(frontmatter_text)
+        if not isinstance(frontmatter, dict):
+            return False, "Frontmatter must be a YAML dictionary"
+    except yaml.YAMLError as e:
+        return False, f"Invalid YAML in frontmatter: {e}"
+
+    # Define allowed properties
+    ALLOWED_PROPERTIES = {'name', 'description', 'license', 'allowed-tools', 'metadata'}
+
+    # Check for unexpected properties (excluding nested keys under metadata)
+    unexpected_keys = set(frontmatter.keys()) - ALLOWED_PROPERTIES
+    if unexpected_keys:
+        return False, (
+            f"Unexpected key(s) in SKILL.md frontmatter: {', '.join(sorted(unexpected_keys))}. "
+            f"Allowed properties are: {', '.join(sorted(ALLOWED_PROPERTIES))}"
+        )
+
+    # Check required fields
+    if 'name' not in frontmatter:
+        return False, "Missing 'name' in frontmatter"
+    if 'description' not in frontmatter:
+        return False, "Missing 'description' in frontmatter"
+
+    # Extract name for validation
+    name = frontmatter.get('name', '')
+    if not isinstance(name, str):
+        return False, f"Name must be a string, got {type(name).__name__}"
+    name = name.strip()
+    if name:
+        # Check naming convention (hyphen-case: lowercase with hyphens)
+        if not re.match(r'^[a-z0-9-]+$', name):
+            return False, f"Name '{name}' should be hyphen-case (lowercase letters, digits, and hyphens only)"
+        if name.startswith('-') or name.endswith('-') or '--' in name:
+            return False, f"Name '{name}' cannot start/end with hyphen or contain consecutive hyphens"
+        # Check name length (max 64 characters per spec)
+        if len(name) > 64:
+            return False, f"Name is too long ({len(name)} characters). Maximum is 64 characters."
+
+    # Extract and validate description
+    description = frontmatter.get('description', '')
+    if not isinstance(description, str):
+        return False, f"Description must be a string, got {type(description).__name__}"
+    description = description.strip()
+    if description:
+        # Check for angle brackets
+        if '<' in description or '>' in description:
+            return False, "Description cannot contain angle brackets (< or >)"
+        # Check description length (max 1024 characters per spec)
+        if len(description) > 1024:
+            return False, f"Description is too long ({len(description)} characters). Maximum is 1024 characters."
+
+    return True, "Skill is valid!"
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        print("Usage: python quick_validate.py <skill_directory>")
+        sys.exit(1)
+    
+    valid, message = validate_skill(sys.argv[1])
+    print(message)
+    sys.exit(0 if valid else 1)

--- a/assets/skills/skill-planner-eval/SKILL.md
+++ b/assets/skills/skill-planner-eval/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: skill-planner-eval
+description: |
+  Evaluates skill planning documents for completeness, accuracy, feasibility, and safety.
+  Use after a plan is drafted (often by skill-planner) and before implementing with skill-creator.
+  Produces a readiness verdict (Approve / Needs Changes / Blocked) with prioritized fixes.
+license: Complete terms in LICENSE.txt
+---
+
+<!-- Model provenance: Generated with a non-Opus 4.5 model/vendor (Copilot CLI session). -->
+
+# Skill Planner Eval
+
+## Purpose
+
+Evaluate a skill plan (typically `.wiki\Copilot\skills\plans\<skill-name>-skill-planning.md`) and decide if it is ready for implementation.
+
+## Inputs to Ask For
+
+- Path to the plan document
+- Any constraints (time budget, allowed tools, environments)
+- Optional: alternate plan variants for comparison
+
+## Output
+
+Produce a structured report with:
+- Verdict: **Approve / Needs Changes / Blocked**
+- Scorecard (rubric categories)
+- Top issues (P0/P1/P2)
+- Concrete edits requested (prefer line-level suggestions)
+- Missing artifacts list
+
+Recommended file output:
+- `.wiki\Copilot\skills\plans\<skill-name>-skill-plan-eval.md`
+
+## Workflow
+
+1. **Parse the plan**: goals, scope, workflow steps, artifacts, dependencies.
+2. **Run the rubric** (see `references\rubric.md`).
+3. **Validate executability**: ensure steps are concrete (repo paths, commands, expected outputs).
+4. **Flag safety risks**: secrets, destructive defaults, privileged/PROD assumptions.
+5. **Write the evaluation report** (see `references\output-template.md`).
+
+## Notes
+
+- If the plan references `.github\skills\...`, remember this repo may require `git add -f` for `.github` paths.
+

--- a/assets/skills/skill-planner-eval/references/output-template.md
+++ b/assets/skills/skill-planner-eval/references/output-template.md
@@ -1,0 +1,42 @@
+# Skill Plan Evaluation Report (Template)
+
+## Inputs
+- Plan: `<path>`
+- Constraints: `<...>`
+- Compared variants (optional): `<...>`
+
+## Verdict
+**Approve / Needs Changes / Blocked**
+
+## Scorecard
+| Category | Pass? | Notes |
+|---|---|---|
+| Scope & success criteria (Gate) |  |  |
+| Exploration evidence (Gate) |  |  |
+| Architecture/data-flow accuracy (Gate) |  |  |
+| Validation plan (Gate) |  |  |
+| Safety/security (Gate) |  |  |
+| Workflow clarity |  |  |
+| Script readiness |  |  |
+| Composition/reuse |  |  |
+| Readability |  |  |
+| Operational realism |  |  |
+
+## Top Issues (Prioritized)
+### P0
+- 
+
+### P1
+- 
+
+### P2
+- 
+
+## Required Edits
+- 
+
+## Missing Artifacts
+- 
+
+## Notes / Risks
+- 

--- a/assets/skills/skill-planner-eval/references/rubric.md
+++ b/assets/skills/skill-planner-eval/references/rubric.md
@@ -1,0 +1,23 @@
+# skill-planner-eval rubric
+
+## Gates (fail any ⇒ Blocked)
+
+1. **Scope & success criteria**: in/out clearly stated; measurable success.
+2. **Exploration evidence**: concrete sources (repo paths, wiki, existing skills) cited.
+3. **Architecture/data-flow accuracy** (if applicable): correct components, dependencies, boundaries.
+4. **Validation plan**: how to validate success safely (prefer lower env / local).
+5. **Safety/security**: no secrets required; privileged actions gated by explicit confirmation.
+
+## Non-gate quality dimensions (score 0–2 each)
+
+- Workflow clarity (stepwise, decision points, required inputs)
+- Script readiness (parameters, safe defaults, testability)
+- Reusability/composition (invokes existing skills vs duplication)
+- Readability (structure, headings, concise)
+- Operational realism (uses repo conventions; realistic commands)
+
+## Severity guidance
+
+- **P0**: blocks execution or unsafe (secrets, PROD impact, missing validation)
+- **P1**: major gaps (missing key sections, ambiguous steps)
+- **P2**: improvements (wording, extra examples)

--- a/assets/skills/skill-planner/SKILL.md
+++ b/assets/skills/skill-planner/SKILL.md
@@ -1,0 +1,184 @@
+---
+name: skill-planner
+description: |
+  Skill planning expert for creating high-quality skill plans before implementation.
+  Use this skill BEFORE skill-creator when you need to:
+  - Plan a new skill from scratch
+  - Analyze requirements and scope for a skill
+  - Decide on skill composition (single vs. split vs. compose with existing skills)
+  - Document architecture and data flows for operational skills
+  - Create comprehensive plan documents ready for execution
+  
+  This skill guides systematic exploration of the codebase, wiki, existing skills,
+  and SRE agents to inform planning decisions. Outputs a plan document in 
+  artifacts/skills/plans/<skill-name>-skill-planning.md that is ready for execution 
+  by skill-creator.
+---
+
+# Skill Planner
+
+This skill provides comprehensive guidance for the planning phase of skill creation. Planning is the most critical aspect of skill creation - a well-planned skill is faster to implement, easier to maintain, and more likely to meet user needs.
+
+## When to Use This Skill
+
+- **Always** before creating a new skill (runs before skill-creator)
+- When deciding whether to split a skill into multiple skills
+- When deciding whether to compose with existing skills
+- When architecture documentation is needed for operational skills
+- For major refactoring of existing skills
+
+## Workflow Position
+
+```
+User Request → skill-planner → Plan Document → User Review → skill-creator → Implementation
+```
+
+## The Planning Process
+
+Follow these phases in order:
+
+### Phase 1: Exploration
+
+Before planning, systematically explore sources. See `references/exploration-checklist.md`.
+
+**Source Priority Order:**
+1. **Existing Skills** (`.github/skills/`) - Avoid duplication, find skills to invoke
+2. **Wiki Documentation** (`artifacts/`) - Architecture, TSGs, sequence diagrams
+3. **Source Code** (`src/`) - Component interactions, data flows
+4. **SRE Agents** (`sreagent/`) - Existing automation, Kusto queries
+5. **Git History** - Recent activity, pain points, common patterns
+6. **External Dependencies** - Partner teams, APIs, tools
+
+**Key Questions:**
+- What existing skills could this skill invoke?
+- What wiki documentation describes this domain?
+- Which source directories are relevant?
+- Are there SRE agents with reusable patterns?
+- What does git history reveal about this area?
+
+### Phase 2: Scope Definition
+
+Define clear boundaries. See `references/scope-framework.md`.
+
+**Must Define:**
+- **In-Scope**: What the skill covers (be specific)
+- **Out-of-Scope**: What is explicitly excluded and why
+- **Dependencies**: Other skills, tools, or services required
+- **Platform Considerations**: Which platforms/environments supported
+
+**Scope Decision Criteria:**
+- Is this a distinct domain? → Consider separate skill
+- Would multiple skills need this? → Create reusable foundational skill
+- Would SKILL.md exceed 500 lines? → Split into references or multiple skills
+
+### Phase 3: Architecture Analysis (If Needed)
+
+Not all skills need architecture documentation. See `references/architecture-patterns.md`.
+
+**When Architecture is Needed:**
+| Skill Type | Need | Depth |
+|------------|------|-------|
+| Operations (RCA, incident, livesite) | ✅ Yes | Deep |
+| Infrastructure (region, scale unit) | ✅ Yes | Medium |
+| Development (connector, API) | ⚠️ Maybe | Light |
+| Utility (formatting, conversion) | ❌ No | N/A |
+
+**What to Document:**
+- Components involved and their roles
+- Data flows (control plane, runtime, OAuth, etc.)
+- Dependencies and failure propagation
+- Relevant Kusto tables for telemetry
+
+### Phase 4: Skill Composition Decision
+
+Decide whether to create one skill or multiple. See `references/composition-framework.md`.
+
+**Decision Tree:**
+1. Does this skill need architectural knowledge?
+   - YES + Would benefit other skills → Create separate architect-style skill
+   - YES + Only this skill needs it → Embed in references/
+   - NO → Continue
+
+2. Is scope too broad (>500 lines, multiple domains)?
+   - YES → Split into multiple skills
+   - NO → Single skill
+
+3. Does this overlap with existing skills?
+   - Significant overlap → Extend existing skill
+   - Partial overlap → Invoke existing skill
+   - No overlap → Create new skill
+
+**Examples:**
+- `rca-helper` was split into `architect` + `rca-assistant` (architecture reusable)
+- `deploy-assistant` stayed single (focused scope)
+- `region-buildout` vs `scale-unit-expansion` are separate (different domains)
+
+### Phase 5: Plan Document Creation
+
+Create the plan document. See `references/plan-template.md`.
+
+**Required Sections:**
+1. Overview (problem + solution)
+2. Scope (in-scope, out-of-scope, dependencies)
+3. Exploration Summary (what was found)
+4. What Gets Created (directory structure)
+5. Key Design Decisions (with rationale)
+6. SKILL.md Structure (outline)
+7. Script Specifications (if any)
+8. Implementation Checklist (phased)
+
+**Output Location:** `artifacts/skills/plans/<skill-name>-skill-planning.md`
+
+### Phase 6: Readiness Assessment
+
+Before marking "Ready to Execute", validate. See `references/readiness-checklist.md`.
+
+**Checklist Categories:**
+- [ ] Exploration complete (all sources consulted)
+- [ ] Scope defined (in/out clear)
+- [ ] Architecture documented (if applicable)
+- [ ] Composition decided (single/split/compose)
+- [ ] Structure complete (all sections present)
+- [ ] Quality checks passed (clear, actionable)
+- [ ] User review complete (feedback incorporated)
+
+## After Planning
+
+Once the plan is approved:
+
+1. Update status in plan document: `📝 Draft` → `✅ Ready to Execute`
+2. Update `artifacts/skills/plans/skills-status.md`
+3. Run **skill-planner-eval** as a gate: `"Evaluate this skill plan with skill-planner-eval"`
+4. If approved, invoke `skill-creator` to implement: `"Execute the <skill-name> skill plan"`
+
+## Key Principles
+
+### Planning vs Implementation
+- Planning is cheap, implementation is expensive
+- Catch issues in the plan, not in code
+- Iterate on plans, not implementations
+
+### Skill Composition
+- Foundational skills (like `architect`) should be invoked, not duplicated
+- Each skill should have a single, clear purpose
+- Prefer composition over monolithic skills
+
+### Documentation Balance
+- SKILL.md should be <500 lines
+- Move detailed content to `references/`
+- Only document what Claude doesn't already know
+
+### Progressive Disclosure
+- Frontmatter (always loaded): name + description
+- SKILL.md body (when triggered): core workflow
+- References (as needed): detailed patterns
+
+## Repository Conventions
+
+| Location | Purpose |
+|----------|---------|
+| `artifacts/skills/plans/` | Plan documents |
+| `artifacts/skills/plans/skills-status.md` | Skill tracking |
+| `.github/skills/` | Implemented skills |
+| `sreagent/` | SRE Agent configurations |
+

--- a/assets/skills/skill-planner/references/architecture-patterns.md
+++ b/assets/skills/skill-planner/references/architecture-patterns.md
@@ -1,0 +1,169 @@
+# Architecture Documentation Patterns
+
+Not all skills need architecture documentation. This guide helps you decide when and how to document architecture.
+
+## When Architecture Documentation is Needed
+
+| Skill Type | Need Architecture? | Depth | Example |
+|------------|-------------------|-------|---------|
+| **Operations** (RCA, incident, livesite) | ✅ Yes | Deep | Components, flows, failures |
+| **Infrastructure** (region, scale unit) | ✅ Yes | Medium | Resources, dependencies |
+| **Development** (connector, API) | ⚠️ Maybe | Light | Relevant APIs only |
+| **Utility** (PDF, formatting) | ❌ No | N/A | - |
+
+**Rule of Thumb:** If the skill needs to understand how requests flow through the system or how failures propagate, document architecture.
+
+## What to Document
+
+### 1. Components Involved
+
+```markdown
+### Components
+| Component | Role in This Skill | Key Interactions |
+|-----------|-------------------|------------------|
+| RP | Connection management | Reads/writes Cosmos |
+| TE | Token exchange | Calls OAuth providers |
+| CS | Consent flow | Stores tokens |
+| SGM | Environment routing | Maps env → scale unit |
+```
+
+### 2. Data Flows
+
+Choose the appropriate pattern based on complexity:
+
+**Pattern 1: Simple Flow (inline text)**
+```
+Client → APIM → TE → Cosmos → Response
+```
+
+**Pattern 2: Box Diagram (component relationships)**
+```
+┌─────────┐     ┌─────────┐     ┌─────────┐
+│ Client  │────▶│  APIM   │────▶│   TE    │
+└─────────┘     └─────────┘     └────┬────┘
+                                     │
+                                     ▼
+                               ┌─────────┐
+                               │ Cosmos  │
+                               └─────────┘
+```
+
+**Pattern 3: Detailed Flow (numbered steps)**
+```markdown
+### Token Exchange Flow
+
+1. Client sends request to Runtime APIM with connection ID
+2. APIM extracts connection ID from headers
+3. APIM calls Token Exchange (TE) to get access token
+4. TE looks up connection in Cosmos (checks Redis cache first)
+5. TE retrieves encrypted refresh token
+6. TE decrypts using Key Vault
+7. TE exchanges refresh token with OAuth provider
+8. TE caches access token in Redis
+9. TE returns access token to APIM
+10. APIM forwards request to backend with access token
+```
+
+**Pattern 4: Multi-tier Architecture**
+```
+┌─────────────────────────────────────────────────────────┐
+│                    SCALE GROUP                           │
+│  ┌─────────────────────────────────────────────────┐    │
+│  │                      SGM                         │    │
+│  │  Environment → Scale Unit routing               │    │
+│  └─────────────────────────────────────────────────┘    │
+│                          │                               │
+│          ┌───────────────┴───────────────┐              │
+│          ▼                               ▼              │
+│  ┌───────────────────┐       ┌───────────────────┐     │
+│  │   Scale Unit 001  │       │   Scale Unit 002  │     │
+│  │  RP, TE, CS, Jobs │       │  RP, TE, CS, Jobs │     │
+│  └───────────────────┘       └───────────────────┘     │
+└─────────────────────────────────────────────────────────┘
+```
+
+### 3. Dependencies
+
+```markdown
+### Component Dependencies
+| Component | Dependencies | Failure Impact |
+|-----------|--------------|----------------|
+| RP | Cosmos, Key Vault, Storage | CRUD operations fail |
+| TE | Cosmos, Redis, Key Vault | Token exchange fails |
+| CS | Cosmos, Redis, External OAuth | Login flow fails |
+| SGM | Cosmos, DNS | Routing fails |
+```
+
+### 4. Failure Propagation
+
+```markdown
+### Failure Impact
+
+**If Cosmos fails:**
+└──▶ All components lose data access
+    └──▶ Complete service outage
+
+**If Redis fails:**
+└──▶ TE/CS cache misses
+    └──▶ Increased Cosmos load
+        └──▶ Potential throttling
+
+**If Key Vault fails:**
+└──▶ Cannot decrypt tokens
+    └──▶ Token exchange fails
+        └──▶ Runtime calls fail
+```
+
+### 5. Relevant Telemetry
+
+```markdown
+### Kusto Tables
+| Component | Primary Table | Key Fields |
+|-----------|---------------|------------|
+| RP | ApiHubRPHttpIncomingRequests | StatusCode, Duration |
+| TE | ApiHubTokenExchangeLogs | ErrorCode, ConnectionId |
+| CS | ApiHubCstSvrRequests | LoginType, Result |
+| SGM | ApiHubSGMLogs | Operation, ScaleUnit |
+```
+
+## Architecture Documentation Template
+
+```markdown
+## Architecture Analysis
+
+### Components Involved
+| Component | Role | Key Interactions |
+|-----------|------|------------------|
+| [Component] | [Role in this skill] | [What it talks to] |
+
+### Data Flow: [Flow Name]
+[Diagram or numbered steps]
+
+### Dependencies
+| Component | Dependencies | Failure Impact |
+|-----------|--------------|----------------|
+| [Component] | [Deps] | [What fails] |
+
+### Failure Propagation
+[Key failure chains relevant to this skill]
+
+### Telemetry Reference
+| Component | Kusto Table | Key Fields |
+|-----------|-------------|------------|
+| [Component] | [Table] | [Fields] |
+```
+
+## When to Create a Separate Architect Skill
+
+Create a separate foundational "architect" skill when:
+
+1. **Multiple skills need the same architecture knowledge**
+   - rca-assistant, incident-investigator, livesite-response all need component knowledge
+   
+2. **Architecture is complex enough to warrant dedicated documentation**
+   - Multi-tier, many components, complex flows
+
+3. **Architecture knowledge has value beyond current skill**
+   - Reusable for future skills
+
+**Example:** The `architect` skill was created because both `rca-assistant` and future `incident-investigator` need component/dependency knowledge.

--- a/assets/skills/skill-planner/references/composition-framework.md
+++ b/assets/skills/skill-planner/references/composition-framework.md
@@ -1,0 +1,206 @@
+# Skill Composition Framework
+
+Deciding whether to create a single skill, split into multiple skills, or compose with existing skills is a critical planning decision.
+
+## Decision Tree
+
+```
+┌─────────────────────────────────────────────────────────────────────────────┐
+│                        SKILL COMPOSITION DECISION                            │
+├─────────────────────────────────────────────────────────────────────────────┤
+│                                                                              │
+│  Q1: Does this skill need architectural/domain knowledge?                    │
+│      │                                                                       │
+│      ├── YES → Q2: Does an existing skill provide this knowledge?           │
+│      │          │                                                            │
+│      │          ├── YES → INVOKE that skill (don't duplicate)               │
+│      │          │                                                            │
+│      │          └── NO → Q3: Would OTHER future skills need this?           │
+│      │                   │                                                   │
+│      │                   ├── YES → CREATE separate foundational skill       │
+│      │                   │         Then INVOKE it from your skill           │
+│      │                   │                                                   │
+│      │                   └── NO → EMBED in references/ of your skill        │
+│      │                                                                       │
+│      └── NO → Continue to Q4                                                │
+│                                                                              │
+│  Q4: Is the scope too broad?                                                 │
+│      │                                                                       │
+│      ├── YES (any of these):                                                │
+│      │   • SKILL.md would exceed 500 lines                                  │
+│      │   • Multiple unrelated workflows                                     │
+│      │   • Different expertise required for parts                           │
+│      │   → SPLIT into multiple focused skills                               │
+│      │                                                                       │
+│      └── NO → Continue to Q5                                                │
+│                                                                              │
+│  Q5: Does this overlap with existing skills?                                 │
+│      │                                                                       │
+│      ├── SIGNIFICANT OVERLAP → EXTEND existing skill instead               │
+│      │                                                                       │
+│      ├── PARTIAL OVERLAP → INVOKE existing skill for shared parts          │
+│      │                                                                       │
+│      └── NO OVERLAP → CREATE new skill                                      │
+│                                                                              │
+└─────────────────────────────────────────────────────────────────────────────┘
+```
+
+## Composition Patterns
+
+### Pattern 1: Single Focused Skill
+
+**When to Use:**
+- Clear, narrow scope
+- SKILL.md < 500 lines
+- Single domain expertise
+- No reusable foundational knowledge
+
+**Example:** `deploy-assistant`
+- Focused on deployment workflows
+- Two related workflows (TIP/DF monitoring, production rollout)
+- No architectural knowledge needed by other skills
+
+```
+deploy-assistant/
+├── SKILL.md
+└── scripts/
+    └── [deployment scripts]
+```
+
+### Pattern 2: Skill Invokes Existing Skill
+
+**When to Use:**
+- Need knowledge another skill already provides
+- Want to leverage existing automation
+- Avoid duplicating documentation
+
+**Example:** `rca-assistant` invokes `architect`
+- rca-assistant needs component/dependency knowledge
+- architect skill already has this knowledge
+- rca-assistant invokes architect for tracing
+
+```
+rca-assistant/
+├── SKILL.md (invokes architect for component tracing)
+└── references/
+    └── [RCA-specific patterns]
+```
+
+**How to Invoke:**
+In SKILL.md:
+```markdown
+## Component Tracing
+
+When you need to understand which components are involved or how failures 
+propagate, consult the `architect` skill by asking:
+
+- "Which component handles [operation]?"
+- "What dependencies does [component] have?"
+- "Trace the data flow for [operation]"
+```
+
+### Pattern 3: Split into Foundational + Operational Skills
+
+**When to Use:**
+- Architecture/domain knowledge is reusable
+- Multiple future skills would need same knowledge
+- Clear separation between "knowledge" and "workflow"
+
+**Example:** `rca-helper` → `architect` + `rca-assistant`
+- Original rca-helper had embedded architecture
+- Architecture knowledge useful for incident-investigator, livesite-response
+- Split: architect (knowledge) + rca-assistant (workflow)
+
+```
+architect/           (foundational - knowledge layer)
+├── SKILL.md
+└── references/
+    ├── components.md
+    ├── data-flows.md
+    └── failure-propagation.md
+
+rca-assistant/       (operational - workflow layer)
+├── SKILL.md (invokes architect)
+└── references/
+    └── investigation-workflow.md
+```
+
+### Pattern 4: Parallel Skills for Different Domains
+
+**When to Use:**
+- Similar structure but different domains
+- Would confuse users if combined
+- Different expertise required
+
+**Example:** `region-buildout` vs `scale-unit-expansion`
+- Both are infrastructure skills
+- Different processes, different prerequisites
+- Kept separate to avoid confusion
+
+```
+region-buildout/           (new regions)
+├── SKILL.md
+└── references/
+
+scale-unit-expansion/      (existing regions)
+├── SKILL.md
+└── references/
+```
+
+## Examples from This Repository
+
+| Original Plan | Problem | Decision | Result |
+|---------------|---------|----------|--------|
+| rca-helper | Architecture embedded, not reusable | Split | `architect` + `rca-assistant` |
+| deploy-assistant | Focused scope, single purpose | Keep single | `deploy-assistant` |
+| region-buildout | Different from scale expansion | Keep separate | Two skills |
+| skill-planner | Distinct from skill-creator | New skill | `skill-planner` |
+
+## Anti-Patterns to Avoid
+
+### ❌ Duplicating Knowledge
+```
+skill-a/
+└── references/architecture.md  ← Duplicated!
+
+skill-b/
+└── references/architecture.md  ← Same content!
+```
+
+**Fix:** Create foundational skill, both invoke it.
+
+### ❌ Monolithic Mega-Skill
+```
+mega-skill/
+├── SKILL.md (1500 lines!)
+└── references/ (20 files)
+```
+
+**Fix:** Split into focused skills.
+
+### ❌ Circular Dependencies
+```
+skill-a invokes skill-b
+skill-b invokes skill-a  ← Circular!
+```
+
+**Fix:** Extract shared knowledge to foundational skill.
+
+## Composition Documentation
+
+When composing skills, document in the plan:
+
+```markdown
+## Skill Composition
+
+### Skills Invoked
+| Skill | Purpose | When Invoked |
+|-------|---------|--------------|
+| architect | Component tracing | When identifying affected components |
+| kusto-helper | Query patterns | When building Kusto queries |
+
+### Rationale
+- `architect` provides reusable component knowledge
+- Avoids duplicating architecture documentation
+- Keeps this skill focused on [specific workflow]
+```

--- a/assets/skills/skill-planner/references/exploration-checklist.md
+++ b/assets/skills/skill-planner/references/exploration-checklist.md
@@ -1,0 +1,166 @@
+# Exploration Checklist
+
+Systematic exploration before planning ensures you understand the domain and avoid duplicating existing work.
+
+## Source Priority Order
+
+Explore sources in this order:
+
+### 1. Existing Skills (.github/skills/)
+
+```powershell
+# List all existing skills
+Get-ChildItem .github/skills -Directory | Select-Object Name
+
+# Read a skill's description
+Get-Content .github/skills/<name>/SKILL.md | Select-Object -First 20
+```
+
+**Look For:**
+- Skills that could be invoked by your new skill
+- Skills with overlapping functionality
+- Patterns to reuse (structure, reference organization)
+- The skill-creator for creation patterns
+
+**Questions:**
+- [ ] What skills already exist?
+- [ ] Which could this skill invoke?
+- [ ] Is there overlap to avoid?
+
+### 2. Wiki Documentation (artifacts/)
+
+```powershell
+# Search wiki for topic
+Get-ChildItem .wiki -Recurse -Filter "*.md" | Select-String -Pattern "topic"
+
+# List key directories
+Get-ChildItem .wiki -Directory | Select-Object Name
+
+# Check sequence diagrams
+Get-ChildItem artifacts/Sequence-Diagrams -Filter "*.mmd"
+```
+
+**Key Locations:**
+- `artifacts/Sequence-Diagrams/` - Data flow diagrams
+- `artifacts/DataLayer/` - Data architecture
+- `artifacts/TSG/` - Troubleshooting guides
+- `artifacts/skills/plans/` - Existing skill plans
+
+**Questions:**
+- [ ] What documentation exists for this domain?
+- [ ] Are there sequence diagrams showing flows?
+- [ ] What TSGs describe operational procedures?
+
+### 3. Source Code (src/)
+
+```powershell
+# List main source directories
+Get-ChildItem src -Directory | Select-Object Name
+
+# Search for patterns in code
+grep -r "pattern" src --include="*.cs" -l
+
+# Find relevant files
+Get-ChildItem src -Recurse -Filter "*keyword*"
+```
+
+**Key Directories:**
+- `src/Administration.ResourceProvider/` - RP (management plane)
+- `src/Consent/ConsentServer.Core/` - CS (OAuth flows)
+- `src/Integration/APIM.RuntimeAdapter/` - TE (token exchange)
+- `src/ScaleGroupManager/` - SGM (routing)
+- `src/Data/` - Data layer, Cosmos
+- `src/Deployment/` - ARM templates
+
+**Questions:**
+- [ ] Which source directories are relevant?
+- [ ] What are the key components?
+- [ ] How do components interact?
+
+### 4. SRE Agents (sreagent/)
+
+```powershell
+# List existing agents
+Get-ChildItem sreagent/agents -Directory | Select-Object Name
+
+# List available tools/queries
+Get-ChildItem sreagent/tools -Filter "*.yaml"
+
+# Read an agent configuration
+Get-Content sreagent/agents/<name>/<name>.yaml
+```
+
+**Look For:**
+- Existing automation patterns
+- Kusto queries to reuse
+- Investigation workflows
+- Handoff relationships between agents
+
+**Questions:**
+- [ ] Are there relevant SRE agents?
+- [ ] What Kusto queries exist?
+- [ ] What investigation patterns are used?
+
+### 5. Git History
+
+```powershell
+# Search commits for keywords
+git log --oneline --all --grep="keyword" | head -20
+
+# Find high-activity files (last 6 months)
+git log --pretty=format: --name-only --since="6 months ago" | sort | uniq -c | sort -rn | head -20
+
+# See recent changes to a directory
+git log --oneline -20 -- src/path/to/dir
+
+# Find commits by pattern in diffs
+git log -p --all -S "pattern" -- "*.cs" | head -100
+```
+
+**Questions:**
+- [ ] What areas have high commit activity?
+- [ ] What patterns emerge from recent changes?
+- [ ] Who are the domain experts (by commit frequency)?
+
+### 6. External Dependencies
+
+**Document:**
+- Partner teams and services
+- Required APIs and authentication
+- CLI tools needed (az, git, node, etc.)
+- External systems (ICM, Kusto, Azure DevOps)
+
+**Questions:**
+- [ ] What external services are involved?
+- [ ] What authentication is required?
+- [ ] What tools must be installed?
+
+## Exploration Summary Template
+
+After exploration, summarize findings:
+
+```markdown
+## Exploration Summary
+
+### Sources Consulted
+- [x] Existing skills: Found `architect`, `skill-creator` relevant
+- [x] Wiki: Reviewed Sequence-Diagrams, DataLayer docs
+- [x] Source code: Analyzed src/Consent, src/Integration
+- [x] SRE agents: Found WebAppAgent, CosmosAgent patterns
+- [x] Git history: High activity in OAuth area (30+ commits)
+- [x] Dependencies: Requires Kusto MCP, icm-reader.js
+
+### Key Findings
+1. Existing `architect` skill can be invoked for component tracing
+2. Sequence diagrams in artifacts/ show OAuth and OBO flows
+3. SRE agents have reusable Kusto query patterns
+4. Git history shows OAuth area has frequent bugs
+
+### Skills to Invoke
+- `architect` - for component and dependency knowledge
+
+### Gaps Identified
+- No existing skill for [specific area]
+- Wiki missing documentation for [topic]
+```
+

--- a/assets/skills/skill-planner/references/plan-template.md
+++ b/assets/skills/skill-planner/references/plan-template.md
@@ -1,0 +1,244 @@
+# Plan Document Template
+
+Use this template for all skill planning documents.
+
+## File Location
+
+`artifacts/skills/plans/<skill-name>-skill-planning.md`
+
+## Template
+
+```markdown
+# [Skill Name] Skill Planning
+
+> **Created**: YYYY-MM-DD  
+> **Last Updated**: YYYY-MM-DDTHH:MM:SSZ  
+> **Status**: 📝 Draft
+
+## Overview
+
+### The Problem
+[What pain point or need does this skill address?]
+[Be specific about who experiences this problem and how often]
+
+### The Solution
+[High-level description of what the skill does]
+[Key capabilities in 2-3 sentences]
+
+---
+
+## Scope
+
+### In-Scope
+| Item | Description |
+|------|-------------|
+| [Feature/Workflow 1] | [What it covers] |
+| [Feature/Workflow 2] | [What it covers] |
+
+### Out-of-Scope (Explicitly Excluded)
+| Item | Reason | Alternative |
+|------|--------|-------------|
+| [Excluded item] | [Why excluded] | [What to use instead] |
+
+### Dependencies
+| Dependency | Type | Notes |
+|------------|------|-------|
+| [Dependency] | Skill/Tool/Permission | [Details] |
+
+### Platform/Environment Support
+| Platform | Supported | Notes |
+|----------|-----------|-------|
+| [Platform] | ✅/❌/⚠️ | [Details] |
+
+---
+
+## Exploration Summary
+
+### Sources Consulted
+- [x] Existing skills: [What was found]
+- [x] Wiki documentation: [What was found]
+- [x] Source code: [What was found]
+- [x] SRE agents: [What was found]
+- [x] Git history: [What was found]
+
+### Key Findings
+1. [Important finding 1]
+2. [Important finding 2]
+3. [Important finding 3]
+
+### Skills to Invoke
+| Skill | Purpose |
+|-------|---------|
+| [skill-name] | [Why this skill invokes it] |
+
+---
+
+## [Domain-Specific Sections]
+
+[Add sections relevant to your skill type]
+
+For Operations skills:
+- Architecture Analysis
+- Component Tracing
+- Failure Modes
+
+For Infrastructure skills:
+- Pre-requisites Checklist
+- Resource Dependencies
+- Validation Steps
+
+For Development skills:
+- API Specifications
+- Code Patterns
+- Testing Approach
+
+---
+
+## What Gets Created
+
+```
+.github/skills/<skill-name>/
+├── SKILL.md                    # [Brief description]
+├── references/
+│   ├── [file1].md              # [What it contains]
+│   └── [file2].md              # [What it contains]
+└── scripts/
+    ├── [script1].ps1           # [What it does]
+    └── [script2].ps1           # [What it does]
+```
+
+**Total: X skill file + Y reference docs + Z scripts = N files**
+
+---
+
+## Key Design Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| [Decision point] | [What was decided] | [Why] |
+| [Decision point] | [What was decided] | [Why] |
+
+---
+
+## SKILL.md Structure
+
+```yaml
+---
+name: [skill-name]
+description: |
+  [2-3 sentence description that includes:]
+  [- What the skill does]
+  [- When to use it (triggers)]
+  [- Key capabilities]
+---
+```
+
+### Main Sections
+1. [Section 1] - [What it covers]
+2. [Section 2] - [What it covers]
+3. [Section 3] - [What it covers]
+
+---
+
+## Script Specifications
+
+### [Script Name].ps1
+
+```powershell
+param(
+    [Parameter(Mandatory)][type]$Param1,
+    [type]$OptionalParam = "default"
+)
+# Purpose: [What the script does]
+# Usage: [Example usage]
+# Returns: [What it outputs]
+```
+
+---
+
+## Implementation Checklist
+
+### Phase 1: Create Skill Structure
+- [ ] Create directory: `.github/skills/<skill-name>/`
+- [ ] Create directory: `.github/skills/<skill-name>/references/`
+- [ ] Create directory: `.github/skills/<skill-name>/scripts/` (if needed)
+- [ ] Create `SKILL.md`
+
+### Phase 2: Create Reference Files
+- [ ] Create `references/[file1].md`
+- [ ] Create `references/[file2].md`
+
+### Phase 3: Create Scripts (if applicable)
+- [ ] Create `scripts/[script1].ps1`
+- [ ] Test script execution
+
+### Phase 4: Validation
+- [ ] Test skill loads in Copilot CLI
+- [ ] Verify workflows function correctly
+- [ ] Update skills-status.md
+
+---
+
+## Validation Criteria
+
+How to know the skill is working correctly:
+
+- [ ] [Criterion 1]
+- [ ] [Criterion 2]
+- [ ] [Criterion 3]
+
+---
+
+## Open Questions
+
+[Items needing user input or decisions]
+
+1. [Question 1]
+2. [Question 2]
+
+---
+
+## Key Repository References
+
+| File/Location | Purpose |
+|---------------|---------|
+| [path] | [Why it's relevant to this skill] |
+
+---
+
+## Session Notes
+
+[Optional: Notes from the planning session]
+```
+
+## Status Values
+
+| Status | Meaning | Next Action |
+|--------|---------|-------------|
+| 📝 Draft | Initial planning | Continue gathering requirements |
+| ✅ Ready to Execute | Plan complete | Run skill-creator to implement |
+| 🚀 Executing | Implementation in progress | Complete implementation |
+| ✔️ Complete | Fully implemented | Available for use |
+| ⏸️ On Hold | Paused | Waiting for [dependency] |
+| ⚠️ Superseded | Replaced by other skill(s) | See replacement |
+
+## Section Guidelines
+
+### Required Sections (always include)
+- Overview (problem + solution)
+- Scope (in-scope, out-of-scope, dependencies)
+- What Gets Created
+- Key Design Decisions
+- Implementation Checklist
+
+### Conditional Sections (include when relevant)
+- Exploration Summary (for complex skills)
+- Architecture Analysis (for operational skills)
+- Script Specifications (when scripts are included)
+- Validation Criteria (for testable skills)
+
+### Optional Sections
+- Open Questions
+- Session Notes
+- Key Repository References
+

--- a/assets/skills/skill-planner/references/readiness-checklist.md
+++ b/assets/skills/skill-planner/references/readiness-checklist.md
@@ -1,0 +1,184 @@
+# Readiness Checklist
+
+Before marking a plan as "✅ Ready to Execute", validate it against this checklist.
+
+## Pre-Execution Validation
+
+### 1. Exploration Complete
+
+- [ ] **Existing skills reviewed**
+  - Listed all relevant existing skills
+  - Identified skills to invoke (if any)
+  - Confirmed no significant duplication
+
+- [ ] **Wiki documentation consulted**
+  - Searched for relevant topics
+  - Reviewed sequence diagrams (if applicable)
+  - Checked TSGs for operational patterns
+
+- [ ] **Source code analyzed** (if applicable)
+  - Identified relevant directories
+  - Understood component interactions
+  - Traced key data flows
+
+- [ ] **SRE agents reviewed** (if applicable)
+  - Checked for existing automation
+  - Identified reusable Kusto queries
+  - Noted investigation patterns
+
+- [ ] **Git history examined** (if applicable)
+  - Identified high-activity areas
+  - Found common patterns/issues
+  - Located domain experts
+
+### 2. Scope Defined
+
+- [ ] **In-scope items listed**
+  - Each item has a clear description
+  - Scope is realistic for v1
+  - No vague or ambiguous items
+
+- [ ] **Out-of-scope items documented**
+  - Each exclusion has a reason
+  - Alternatives provided where appropriate
+  - No gaps (nothing implicitly out of scope)
+
+- [ ] **Dependencies identified**
+  - Skills to invoke listed
+  - Required tools/CLIs noted
+  - Permissions documented
+
+- [ ] **Platform support clarified**
+  - Supported platforms listed
+  - Unsupported platforms noted with reasons
+
+### 3. Architecture Documented (If Applicable)
+
+Skip if skill doesn't need architecture documentation.
+
+- [ ] **Components identified**
+  - Role of each component clear
+  - Key interactions documented
+
+- [ ] **Data flows documented**
+  - Relevant flows diagrammed/described
+  - Request paths clear
+
+- [ ] **Dependencies mapped**
+  - Component → dependency relationships
+  - Failure impact noted
+
+- [ ] **Telemetry referenced**
+  - Relevant Kusto tables listed
+  - Key fields identified
+
+### 4. Composition Decided
+
+- [ ] **Single vs. split decision made**
+  - Rationale documented
+  - If split: all resulting skills identified
+
+- [ ] **Skills to invoke identified**
+  - How and when to invoke documented
+  - No circular dependencies
+
+- [ ] **No unnecessary duplication**
+  - Checked against existing skills
+  - Foundational knowledge not duplicated
+
+### 5. Structure Complete
+
+- [ ] **All required sections present**
+  - Overview (problem + solution)
+  - Scope (in-scope, out-of-scope, dependencies)
+  - What Gets Created (directory structure)
+  - Key Design Decisions
+  - Implementation Checklist
+
+- [ ] **File structure defined**
+  - SKILL.md outline complete
+  - Reference files listed with descriptions
+  - Scripts specified (if any)
+
+- [ ] **Implementation checklist created**
+  - Phased tasks
+  - Clear checkboxes
+  - Validation steps included
+
+### 6. Quality Checks
+
+- [ ] **Problem statement is clear**
+  - Reader understands the pain point
+  - Specific, not vague
+
+- [ ] **Solution is actionable**
+  - Clear what the skill does
+  - Practical to implement
+
+- [ ] **Scope is realistic**
+  - Not trying to do too much in v1
+  - Can be extended later
+
+- [ ] **Decisions are documented**
+  - Key choices explained
+  - Rationale provided
+
+- [ ] **Open questions listed**
+  - Items needing user input identified
+  - No hidden assumptions
+
+### 7. User Review
+
+- [ ] **Plan presented to user**
+  - Summary shared
+  - Key decisions highlighted
+
+- [ ] **Feedback incorporated**
+  - User comments addressed
+  - Changes made as needed
+
+- [ ] **Approval received**
+  - User confirmed plan is ready
+  - No outstanding concerns
+
+## Ready to Execute
+
+When all applicable items are checked:
+
+1. Update plan status: `📝 Draft` → `✅ Ready to Execute`
+2. Update `artifacts/skills/plans/skills-status.md`
+3. Proceed to skill-creator: `"Execute the <skill-name> skill plan"`
+
+## Quick Validation
+
+For simple skills, use this abbreviated checklist:
+
+```markdown
+## Quick Readiness Check
+
+- [ ] Problem clearly stated
+- [ ] Scope defined (in/out)
+- [ ] File structure complete
+- [ ] Key decisions documented
+- [ ] Implementation checklist present
+- [ ] User approved
+```
+
+## Common Issues
+
+### Plan Not Ready If:
+
+❌ **Vague scope**: "Handle connections" instead of specific operations
+❌ **Missing rationale**: Decisions without "why"
+❌ **No file structure**: "Will figure out during implementation"
+❌ **Hidden assumptions**: Things the user should know but aren't stated
+❌ **Scope creep indicators**: "Also maybe add..." without proper scoping
+
+### How to Fix:
+
+1. **Vague scope** → Add specific items with descriptions
+2. **Missing rationale** → Add "Rationale" column to decisions table
+3. **No file structure** → Define complete directory structure
+4. **Hidden assumptions** → Add to "Open Questions" or document
+5. **Scope creep** → Move to "Future Enhancements" or explicitly exclude
+

--- a/assets/skills/skill-planner/references/scope-framework.md
+++ b/assets/skills/skill-planner/references/scope-framework.md
@@ -1,0 +1,149 @@
+# Scope Definition Framework
+
+Clear scope definition prevents scope creep and ensures focused, maintainable skills.
+
+## Required Scope Elements
+
+Every skill plan must define:
+
+### 1. In-Scope
+
+What the skill explicitly covers:
+
+```markdown
+## Scope
+
+### In-Scope
+| Item | Description |
+|------|-------------|
+| Feature A | Create, update, delete operations for X |
+| Workflow B | Step-by-step guide for Y process |
+| Platform C | Support for Power Platform environments |
+```
+
+**Be Specific:**
+- ❌ "Handle connections" (too vague)
+- ✅ "Create OAuth connections for 3P connectors"
+
+### 2. Out-of-Scope
+
+What is explicitly excluded and why:
+
+```markdown
+### Out-of-Scope
+| Item | Reason | Alternative |
+|------|--------|-------------|
+| Logic Apps | Different architecture | Future: logic-apps-skill |
+| Sovereign clouds | Different auth model | See TSG for manual process |
+| v2 API | Not yet stable | Will add in future version |
+```
+
+**Always Provide:**
+- Clear reason for exclusion
+- Alternative or future plan
+
+### 3. Dependencies
+
+What the skill requires:
+
+```markdown
+### Dependencies
+| Dependency | Type | Notes |
+|------------|------|-------|
+| architect | Skill (invokes) | For component tracing |
+| Kusto MCP | Tool | For telemetry queries |
+| az CLI | Tool | Must be installed and authenticated |
+| ICM access | Permission | Browser auth required |
+```
+
+**Dependency Types:**
+- **Skill (invokes)** - Another skill this skill calls
+- **Tool** - External CLI or service
+- **Permission** - Access rights needed
+- **Service** - External API or system
+
+### 4. Platform/Environment Considerations
+
+```markdown
+### Platform Support
+| Platform | Supported | Notes |
+|----------|-----------|-------|
+| Power Platform | ✅ Yes | Primary focus |
+| Logic Apps | ❌ No | Different architecture |
+| Sovereign (USGov) | ⚠️ Limited | Some features unavailable |
+| Local dev | ✅ Yes | With emulator |
+```
+
+## Scope Decision Criteria
+
+Use these questions to determine scope:
+
+### Should This Be a Separate Skill?
+
+| Question | If Yes | If No |
+|----------|--------|-------|
+| Is this a distinct domain? | Separate skill | Include in current |
+| Would multiple skills need this knowledge? | Create foundational skill | Embed in current |
+| Does this require different expertise? | Separate skill | Include in current |
+| Is this optional/advanced functionality? | Move to references/ | Include in SKILL.md |
+
+### Should This Be Split?
+
+| Signal | Action |
+|--------|--------|
+| SKILL.md would exceed 500 lines | Split into references or multiple skills |
+| Multiple unrelated workflows | Consider separate skills per workflow |
+| Platform-specific variations | Consider platform-specific skills |
+| Reusable architecture knowledge | Extract to foundational skill |
+
+### Examples from This Repository
+
+| Original | Decision | Result |
+|----------|----------|--------|
+| rca-helper (embedded architecture) | Architecture reusable | Split: `architect` + `rca-assistant` |
+| deploy-assistant | Focused scope | Single skill |
+| region-buildout vs scale-unit | Different domains | Two separate skills |
+
+## Scope Negotiation
+
+When scope is unclear, ask clarifying questions:
+
+```markdown
+Before I plan this skill, I need to understand the scope:
+
+1. **Platforms**: Should this support Power Platform only, or also Logic Apps?
+2. **Environments**: Production only, or also TIP/DF?
+3. **Clouds**: Public Azure only, or also sovereign clouds?
+4. **Depth**: Quick reference or comprehensive guide?
+5. **Automation**: Guidance only, or scripts for automation?
+```
+
+## Scope Documentation Template
+
+```markdown
+## Scope
+
+### In-Scope
+| Item | Description |
+|------|-------------|
+| [Feature 1] | [What it covers] |
+| [Feature 2] | [What it covers] |
+
+### Out-of-Scope (Explicitly Excluded)
+| Item | Reason | Alternative |
+|------|--------|-------------|
+| [Excluded 1] | [Why] | [What to use instead] |
+| [Excluded 2] | [Why] | [Future plans] |
+
+### Dependencies
+| Dependency | Type | Notes |
+|------------|------|-------|
+| [Dep 1] | [Type] | [Details] |
+| [Dep 2] | [Type] | [Details] |
+
+### Platform/Environment Support
+| Platform | Supported | Notes |
+|----------|-----------|-------|
+| [Platform 1] | ✅/❌/⚠️ | [Details] |
+| [Platform 2] | ✅/❌/⚠️ | [Details] |
+```

--- a/assets/skills/skill-reskilling/SKILL.md
+++ b/assets/skills/skill-reskilling/SKILL.md
@@ -1,0 +1,129 @@
+---
+name: skill-reskilling
+description: |
+  Continuous learning and improvement for existing skills.
+  Use this skill when you want to:
+  - Refresh a skill that may have drifted from current best practices
+  - Incorporate feedback from evals, PRs, or users
+  - Update a skill after upstream knowledge sources changed (wiki, code, SRE agents)
+  - Prune stale or incorrect guidance from a skill
+  
+  Reskilling uses planner-style exploration to collect signals, proposes changes
+  (upskill/update/unlearn), validates via eval skills, and applies edits directly.
+license: Complete terms in LICENSE.txt
+---
+
+<!-- Model provenance: Generated with a non-Opus 4.5 model/vendor (Copilot CLI session). -->
+
+# Skill Reskilling
+
+Continuously improve existing skills based on signals from git history, eval outputs, wiki changes, and user feedback.
+
+## When to Use
+
+- Skill hasn't been updated in 90+ days
+- Eval failure or user-reported issue
+- Upstream knowledge sources changed significantly
+- User explicitly requests: "reskill \<skill-name\>"
+
+## Quick Start
+
+```
+"Reskill the deploy-assistant skill"
+```
+
+## Inputs to Ask For
+
+1. **Which skill?** — name or path (e.g., `skill-planner`, `deploy-assistant`)
+2. **Any specific feedback?** — optional: known issues, PR comments, user requests
+3. **Time window?** — default: 90 days or since last reskill
+4. **Auto-apply or proposal-only?** — default: proposal-only (safer)
+
+## Workflow
+
+### Phase 1: Signal Collection
+
+Gather reskilling signals. See `references/signal-sources.md`.
+
+| Source | What to Look For |
+|--------|------------------|
+| Git history | Commits touching the skill or its domain; bug fixes; reverts |
+| Eval outputs | Past `skill-planner-eval` or `skill-creator-eval` reports |
+| Wiki diffs | Changes to referenced wiki pages since skill was last updated |
+| User feedback | Explicit requests, PR comments, issues |
+| Dependent skills | If this skill is invoked by others, check their status |
+
+### Phase 2: Categorize Changes
+
+Classify signals. See `references/change-categories.md`.
+
+| Type | Description | Example |
+|------|-------------|---------|
+| **Upskill** | Add new capability or knowledge | New workflow step, new tool support |
+| **Update** | Correct or refresh existing content | Path changed, better example |
+| **Unlearn** | Remove obsolete or incorrect guidance | Deprecated pattern, wrong command |
+
+### Phase 3: Draft Proposal
+
+Produce a structured proposal. See `references/proposal-template.md`.
+
+Output file: `.wiki\Copilot\skills\plans\<skill-name>-reskilling-proposal.md`
+
+### Phase 4: Validate Proposal
+
+Run `skill-planner-eval` on the proposal.
+
+Gate: proceed only if verdict is **Approve** or **Needs Changes**.
+
+### Phase 5: Apply Edits
+
+Directly edit existing skill files (SKILL.md, references, scripts).
+
+This is **update**, not create—no scaffolding.
+
+### Phase 6: Validate Updated Skill
+
+Run `skill-creator-eval` on the updated skill directory.
+
+Gate: proceed to commit only if verdict is **Approve** or **Needs Changes**.
+
+### Phase 7: Document
+
+- Add changelog entry (in skill or `skills-status.md`)
+- Update `Last Reskilled` timestamp
+
+## Example Invocations
+
+| Command | What Happens |
+|---------|--------------|
+| `"Reskill skill-planner"` | Analyze for drift, propose updates |
+| `"Reskill deploy-assistant based on recent PR feedback"` | Focus on specific feedback |
+| `"Reskill architect skill - check wiki changes"` | Focus on wiki signals |
+| `"Show reskilling proposal for rca-assistant (don't apply)"` | Proposal-only mode |
+
+## Outputs
+
+1. **Signal summary**: what changed (git, wiki, evals, feedback)
+2. **Reskilling proposal**: table of upskill/update/unlearn changes
+3. **Validation results**: eval verdicts
+4. **Updated files** (if approved): edited skill files
+5. **Changelog entry**: documented in `skills-status.md`
+
+## Tips
+
+- Start with **proposal-only mode** until you trust the process
+- Review signal summary before approving changes
+- If eval returns "Blocked", address P0 issues before retrying
+- Use specific feedback to guide targeted reskilling
+
+## Continuous Loop
+
+```
+Trigger → Collect Signals → Propose → Validate (plan-eval) → Apply → Validate (skill-eval) → Document → (repeat)
+```
+
+Triggers:
+- Manual: user says "reskill \<skill-name\>"
+- Time-based: skill not reskilled in 90+ days
+- Event-based: eval failure, wiki change, user feedback
+

--- a/assets/skills/skill-reskilling/references/autonomic-principles.md
+++ b/assets/skills/skill-reskilling/references/autonomic-principles.md
@@ -1,0 +1,66 @@
+# Autonomic Principles for Skills
+
+Applying self-* properties from autonomic computing to skill maintenance.
+
+## Background
+
+Autonomic computing (IBM, 2001) defines self-managing systems with these properties:
+- Self-configuration
+- Self-healing
+- Self-optimization
+- Self-learning
+
+Reference: https://en.wikipedia.org/wiki/Autonomic_computing
+
+## Application to Skills
+
+| Property | Traditional Software | Skills (via Reskilling) |
+|----------|---------------------|-------------------------|
+| **Self-configuration** | System adapts to new hardware/network | Skill adapts to new repo structure, tools, paths |
+| **Self-healing** | System detects and corrects faults | Skill corrects itself after eval failure or user report |
+| **Self-optimization** | System tunes performance | Skill prunes redundant content, improves clarity |
+| **Self-learning** | System learns from experience | Skill incorporates patterns from git history, wiki changes |
+
+## The MAPE Loop
+
+Autonomic systems use Monitor-Analyze-Plan-Execute (MAPE):
+
+```
+Monitor → Analyze → Plan → Execute → (repeat)
+```
+
+For skills:
+
+| MAPE Phase | Reskilling Equivalent |
+|------------|----------------------|
+| Monitor | Signal collection (git, wiki, evals, feedback) |
+| Analyze | Categorize changes (upskill/update/unlearn) |
+| Plan | Draft proposal, validate with `skill-planner-eval` |
+| Execute | Apply edits, validate with `skill-creator-eval`, document |
+
+## Compounding Effect
+
+From compounding engineering (Every.to):
+> "Each unit of work should make subsequent units easier—not harder."
+
+Applied to skills:
+- Each reskilling cycle captures lessons permanently
+- Eval failures become documented fixes
+- User feedback becomes improved guidance
+- The skill gets better over time, not worse
+
+## Trigger Model
+
+| Trigger Type | Example | Frequency |
+|--------------|---------|-----------|
+| **Manual** | User says "reskill X" | On demand |
+| **Time-based** | Skill not reskilled in 90+ days | Periodic |
+| **Event-based** | Eval failure, wiki change | Reactive |
+
+## Goal
+
+Skills should behave like well-maintained software:
+- Actively monitored for drift
+- Quickly corrected when wrong
+- Continuously improved over time
+- Never allowed to rot silently

--- a/assets/skills/skill-reskilling/references/change-categories.md
+++ b/assets/skills/skill-reskilling/references/change-categories.md
@@ -1,0 +1,85 @@
+# Change Categories for Reskilling
+
+How to classify reskilling signals into actionable changes.
+
+## Categories
+
+### 1. Upskill
+
+**Definition**: Add new capability or knowledge that didn't exist before.
+
+**Triggers**:
+- New workflow or tool added to the domain
+- New wiki documentation that should be referenced
+- User request for new functionality
+- Dependent skill added new capability this skill should leverage
+
+**Examples**:
+- Add support for a new deployment target
+- Reference a new TSG that was created
+- Add a new phase to the workflow
+
+**Risk**: Low (additive change)
+
+---
+
+### 2. Update
+
+**Definition**: Correct or refresh existing content to match current state.
+
+**Triggers**:
+- Path or file renamed
+- Command syntax changed
+- Better example discovered
+- Wording unclear (based on user feedback)
+
+**Examples**:
+- Update a script path that moved
+- Fix a command that now has different flags
+- Improve an example that confused users
+
+**Risk**: Medium (existing content changes)
+
+---
+
+### 3. Unlearn
+
+**Definition**: Remove obsolete, incorrect, or harmful guidance.
+
+**Triggers**:
+- Pattern deprecated
+- Guidance caused user error
+- Eval flagged as unsafe or incorrect
+- Duplicate of content now in another skill
+
+**Examples**:
+- Remove reference to deprecated API
+- Delete workflow step that's no longer needed
+- Prune section that duplicates another skill
+
+**Risk**: High (removal is harder to undo)
+
+---
+
+## Decision Matrix
+
+| Signal | Likely Category | Confidence |
+|--------|-----------------|------------|
+| New wiki page in domain | Upskill | High |
+| Wiki page edited | Update | Medium |
+| Wiki page deleted | Unlearn | High |
+| Git revert in skill | Update or Unlearn | Medium |
+| User says "this is wrong" | Update or Unlearn | High |
+| User says "can you also do X" | Upskill | High |
+| Eval P0: unsafe | Unlearn | High |
+| Eval P1: missing section | Upskill | Medium |
+| Eval P2: wording | Update | Low |
+
+---
+
+## Handling Conflicts
+
+When signals suggest conflicting changes:
+1. Surface the conflict to the user
+2. Ask for clarification
+3. Default to the safer option (usually Update over Unlearn)

--- a/assets/skills/skill-reskilling/references/proposal-template.md
+++ b/assets/skills/skill-reskilling/references/proposal-template.md
@@ -1,0 +1,75 @@
+# Reskilling Proposal Template
+
+Use this structure for reskilling proposals.
+
+---
+
+## Reskilling Proposal: \<skill-name\>
+
+> **Generated**: \<timestamp\>  
+> **Target Skill**: `.github/skills/<skill-name>/`  
+> **Last Updated**: \<skill-last-updated\>  
+> **Time Window Analyzed**: \<start\> to \<end\>
+
+---
+
+### Signal Summary
+
+| Source | Signals Found | Details |
+|--------|---------------|---------|
+| Git history | X commits | ... |
+| Eval outputs | X issues | ... |
+| Wiki diffs | X pages changed | ... |
+| User feedback | X items | ... |
+| Dependent skills | X updated | ... |
+
+---
+
+### Proposed Changes
+
+| # | Type | Section/File | Change | Rationale | Risk |
+|---|------|--------------|--------|-----------|------|
+| 1 | Upskill | ... | ... | ... | Low |
+| 2 | Update | ... | ... | ... | Medium |
+| 3 | Unlearn | ... | ... | ... | High |
+
+---
+
+### Risk Assessment
+
+**Overall Risk**: Low / Medium / High
+
+**Key Risks**:
+- ...
+
+**Mitigation**:
+- ...
+
+---
+
+### Validation Plan
+
+1. Run `skill-planner-eval` on this proposal
+2. If approved, apply edits to skill files
+3. Run `skill-creator-eval` on updated skill
+4. If approved, commit and document
+
+---
+
+### Files to Edit
+
+- `.github/skills/<skill-name>/SKILL.md`
+- `.github/skills/<skill-name>/references/...`
+- `artifacts/skills/plans/skills-status.md` (update timestamp)
+
+---
+
+### Approval
+
+- [ ] User reviewed signal summary
+- [ ] User approved proposed changes
+- [ ] `skill-planner-eval` passed
+- [ ] Edits applied
+- [ ] `skill-creator-eval` passed
+- [ ] Committed and documented
+

--- a/assets/skills/skill-reskilling/references/signal-sources.md
+++ b/assets/skills/skill-reskilling/references/signal-sources.md
@@ -1,0 +1,82 @@
+# Signal Sources for Reskilling
+
+Where to look for signals that a skill needs reskilling.
+
+## Primary Sources
+
+### 1. Git History
+```powershell
+# Commits touching the skill directory
+git --no-pager log --oneline --since="90 days ago" -- .github/skills/<skill-name>/
+
+# Commits touching the skill's domain (e.g., deploy-related code)
+git --no-pager log --oneline --since="90 days ago" -- src/<relevant-paths>/
+```
+
+Look for:
+- Bug fixes in the skill itself
+- Reverts (something was wrong)
+- Changes to referenced code/scripts
+
+### 2. Eval Outputs
+
+Check for past evaluation reports:
+- `artifacts/skills/plans/<skill-name>-skill-plan-eval.md`
+- `artifacts/skills/plans/<skill-name>-skill-eval.md`
+
+Look for:
+- P0/P1 issues that were flagged
+- Recurring patterns across evals
+
+### 3. Wiki Diffs
+
+Check if referenced wiki pages changed:
+```powershell
+# Changes to wiki since skill was last updated
+git --no-pager log --oneline --since="<skill-last-updated>" -- artifacts/
+```
+
+Look for:
+- Architecture changes
+- New TSGs or workflows
+- Deprecated patterns
+
+### 4. User Feedback
+
+Sources:
+- PR comments on the skill
+- Issues mentioning the skill
+- Direct user requests ("this skill told me the wrong thing")
+
+### 5. Dependent Skills
+
+If this skill is invoked by others:
+```powershell
+# Find skills that reference this skill
+grep -r "<skill-name>" .github/skills/ --include="*.md"
+```
+
+Check if dependent skills have been updated and this one hasn't.
+
+## Secondary Sources
+
+### 6. SRE Agent Changes
+```powershell
+git --no-pager log --oneline --since="90 days ago" -- sreagent/
+```
+
+### 7. External API/Tool Changes
+
+If the skill references external tools (az CLI, npm, etc.), check for version changes or deprecations.
+
+## Signal Priority
+
+| Priority | Source | Why |
+|----------|--------|-----|
+| P0 | Eval failures (Blocked) | Skill is broken |
+| P0 | User reports | Direct evidence of problem |
+| P1 | Git reverts | Something was wrong |
+| P1 | Wiki architecture changes | Core knowledge may be stale |
+| P2 | Code path changes | References may be outdated |
+| P2 | Time since last reskill | Preventive maintenance |
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,9 @@
         "react": "^19.2.4",
         "simple-git": "^3.30.0"
       },
+      "bin": {
+        "primer": "dist/index.js"
+      },
       "devDependencies": {
         "@types/node": "^25.1.0",
         "@types/react": "^19.2.10",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -35,7 +35,7 @@ export function runCli(argv: string[]): void {
 
   program
     .command("generate")
-    .argument("<type>", "prompts|agents|mcp|vscode|aiignore")
+    .argument("<type>", "mcp|vscode|skills")
     .argument("[path]", "Path to a local repository")
     .option("--force", "Overwrite existing files")
     .action(generateCommand);

--- a/src/commands/generate.ts
+++ b/src/commands/generate.ts
@@ -7,9 +7,9 @@ type GenerateOptions = {
 };
 
 export async function generateCommand(type: string, repoPathArg: string | undefined, options: GenerateOptions): Promise<void> {
-  const allowed = new Set(["mcp", "vscode"]);
+  const allowed = new Set(["mcp", "vscode", "skills"]);
   if (!allowed.has(type)) {
-    console.error("Invalid type. Use: mcp, vscode.");
+    console.error("Invalid type. Use: mcp, vscode, skills.");
     process.exitCode = 1;
     return;
   }

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -60,7 +60,8 @@ export async function initCommand(repoPathArg: string | undefined, options: Init
         choices: [
           { name: "Custom instructions (.github/copilot-instructions.md)", value: "instructions" },
           { name: "MCP configuration", value: "mcp" },
-          { name: "VS Code settings", value: "vscode" }
+          { name: "VS Code settings", value: "vscode" },
+          { name: "Meta-skills for skill authoring (.github/skills/)", value: "skills" }
         ],
         required: true
       });

--- a/src/services/generator.ts
+++ b/src/services/generator.ts
@@ -1,6 +1,7 @@
 import path from "path";
 import { RepoAnalysis } from "./analyzer";
 import { ensureDir, safeWriteFile } from "../utils/fs";
+import { copySkillsToRepo } from "./skills";
 
 export type GenerateOptions = {
   repoPath: string;
@@ -30,6 +31,10 @@ export async function generateConfigs(options: GenerateOptions): Promise<{ summa
     actions.push(result);
   }
 
+  if (selections.includes("skills")) {
+    const result = await copySkillsToRepo({ repoPath, force });
+    actions.push(result.summary);
+  }
 
   const summary = actions.length ? `\n${actions.join("\n")}` : "No changes made.";
   return { summary };

--- a/src/services/skills.ts
+++ b/src/services/skills.ts
@@ -1,0 +1,86 @@
+import path from "path";
+import fs from "fs/promises";
+import { fileURLToPath } from "url";
+import { ensureDir, safeWriteFile } from "../utils/fs";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+/** Path to bundled skills assets */
+const ASSETS_DIR = path.resolve(__dirname, "../../assets/skills");
+
+/** Meta-skills that get copied to target repos */
+const META_SKILLS = [
+  "skill-creator",
+  "skill-planner",
+  "skill-reskilling",
+  "skill-creator-eval",
+  "skill-planner-eval"
+];
+
+export type CopySkillsOptions = {
+  repoPath: string;
+  force: boolean;
+};
+
+/**
+ * Recursively copy a directory
+ */
+async function copyDir(src: string, dest: string, force: boolean): Promise<string[]> {
+  const actions: string[] = [];
+  await ensureDir(dest);
+
+  const entries = await fs.readdir(src, { withFileTypes: true });
+  for (const entry of entries) {
+    const srcPath = path.join(src, entry.name);
+    const destPath = path.join(dest, entry.name);
+
+    if (entry.isDirectory()) {
+      const subActions = await copyDir(srcPath, destPath, force);
+      actions.push(...subActions);
+    } else {
+      const content = await fs.readFile(srcPath, "utf8");
+      const result = await safeWriteFile(destPath, content, force);
+      actions.push(result);
+    }
+  }
+  return actions;
+}
+
+/**
+ * Copy meta-skills to target repository's .github/skills/ directory
+ */
+export async function copySkillsToRepo(options: CopySkillsOptions): Promise<{ summary: string }> {
+  const { repoPath, force } = options;
+  const actions: string[] = [];
+
+  // Copy each meta-skill
+  const skillsDestDir = path.join(repoPath, ".github", "skills");
+  for (const skillName of META_SKILLS) {
+    const srcDir = path.join(ASSETS_DIR, skillName);
+    const destDir = path.join(skillsDestDir, skillName);
+    
+    try {
+      await fs.access(srcDir);
+      const skillActions = await copyDir(srcDir, destDir, force);
+      actions.push(...skillActions);
+    } catch {
+      actions.push(`⚠️ Skill not found: ${skillName}`);
+    }
+  }
+
+  // Copy artifacts/skills/plans scaffolding
+  const artifactsSrc = path.join(ASSETS_DIR, "artifacts", "skills", "plans");
+  const artifactsDest = path.join(repoPath, "artifacts", "skills", "plans");
+  
+  try {
+    await fs.access(artifactsSrc);
+    const artifactActions = await copyDir(artifactsSrc, artifactsDest, force);
+    actions.push(...artifactActions);
+  } catch {
+    actions.push("⚠️ Artifacts scaffolding not found");
+  }
+
+  const summary = actions.length ? `\n${actions.join("\n")}` : "No skills copied.";
+  return { summary };
+}


### PR DESCRIPTION
Summary

merging the meta-skills from https://github.com/annaji-msft/skills-starter-kit

  This PR extends Primer to support skills generation - copying meta-skills for skill authoring to target repositories. Skills are modular packages that extend AI capabilities with specialized workflows, and this feature enables teams to quickly
  bootstrap their skill authoring infrastructure.

  What's Added

  New command: generate skills

    npx tsx src/index.ts generate skills [path] [--force]

  Bundled meta-skills (5 total):

    - skill-creator - Guide for creating effective skills with scripts for init/package/validate
    - skill-planner - Planning expert for skill design before implementation
    - skill-reskilling - Maintain and update skills over time
    - skill-creator-eval - Evaluate implemented skills before shipping
    - skill-planner-eval - Evaluate skill plans before execution

  Also includes:

    - artifacts/skills/plans/ scaffolding for skill planning workflow
    - Skills option in interactive init command

  Usage

    # Generate skills to current directory
    npx tsx src/index.ts generate skills

    # Generate to specific repo with force overwrite
    npx tsx src/index.ts generate skills /path/to/repo --force

    # Or via interactive init
    npx tsx src/index.ts init
    # → Select "Meta-skills for skill authoring (.github/skills/)"

  Output Structure

  After running, target repos will have:

    repo/
    ├── .github/
    │   └── skills/
    │       ├── skill-creator/
    │       ├── skill-planner/
    │       ├── skill-reskilling/
    │       ├── skill-creator-eval/
    │       └── skill-planner-eval/
    └── artifacts/
        └── skills/
            └── plans/
                ├── README.md
                └── skills-status.md

  Design Decisions

    - Bundled as static assets - Skills are copied from assets/skills/ rather than dynamically generated, ensuring consistency and enabling upstream updates
    - Same pattern as existing generators - Uses the existing generate command pattern (like mcp/vscode) for consistency
    - Supports --force flag - Consistent with other generate types for overwriting existing files
    - Progressive disclosure - Skills follow the SKILL.md + references pattern to minimize context window usage

  Testing

  Tested locally - generates all 5 skills and artifacts scaffolding successfully.