### PR TITLE
Add --accessible flag for screen reader support

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -17,7 +17,8 @@ export function runCli(argv: string[]): void {
   program
     .name("primer")
     .description("Prime repositories for AI-assisted development")
-    .version("0.1.0");
+    .version("0.1.0")
+    .option("--accessible", "Enable screen reader friendly output (removes box-drawing characters, replaces Unicode symbols with text)");
 
   program
     .command("init")

--- a/src/commands/batch.tsx
+++ b/src/commands/batch.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { render } from "ink";
+import { Command } from "commander";
 import { BatchTui } from "../ui/BatchTui";
 import { getGitHubToken } from "../services/github";
 
@@ -7,9 +8,9 @@ type BatchOptions = {
   output?: string;
 };
 
-export async function batchCommand(options: BatchOptions): Promise<void> {
+export async function batchCommand(options: BatchOptions, cmd: Command): Promise<void> {
   const token = await getGitHubToken();
-  
+
   if (!token) {
     console.error("Error: GitHub authentication required.");
     console.error("");
@@ -22,10 +23,11 @@ export async function batchCommand(options: BatchOptions): Promise<void> {
     return;
   }
 
+  const accessible = cmd.parent?.opts().accessible || process.env.INK_SCREEN_READER === "true";
   const { waitUntilExit } = render(
-    <BatchTui token={token} outputPath={options.output} />
+    <BatchTui token={token} outputPath={options.output} accessible={accessible} />,
+    { isScreenReaderEnabled: accessible }
   );
-
 
   await waitUntilExit();
 }

--- a/src/commands/tui.tsx
+++ b/src/commands/tui.tsx
@@ -1,6 +1,7 @@
 import path from "path";
 import React from "react";
 import { render } from "ink";
+import { Command } from "commander";
 import { PrimerTui } from "../ui/tui";
 
 type TuiOptions = {
@@ -8,9 +9,13 @@ type TuiOptions = {
   animation?: boolean;
 };
 
-export async function tuiCommand(options: TuiOptions): Promise<void> {
+export async function tuiCommand(options: TuiOptions, cmd: Command): Promise<void> {
   const repoPath = path.resolve(options.repo ?? process.cwd());
   const skipAnimation = options.animation === false;
-  const { waitUntilExit } = render(<PrimerTui repoPath={repoPath} skipAnimation={skipAnimation} />);
+  const accessible = cmd.parent?.opts().accessible || process.env.INK_SCREEN_READER === "true";
+  const { waitUntilExit } = render(
+    <PrimerTui repoPath={repoPath} skipAnimation={skipAnimation || accessible} accessible={accessible} />,
+    { isScreenReaderEnabled: accessible }
+  );
   await waitUntilExit();
 }

--- a/src/ui/AnimatedBanner.tsx
+++ b/src/ui/AnimatedBanner.tsx
@@ -121,10 +121,19 @@ export function AnimatedBanner({
 
 /**
  * Static banner for use after animation or when animation is disabled.
+ * When accessible=true, renders plain text instead of block art.
  */
-export function StaticBanner({ darkMode = true }: { darkMode?: boolean }): React.JSX.Element {
+export function StaticBanner({ darkMode = true, accessible = false }: { darkMode?: boolean; accessible?: boolean }): React.JSX.Element {
   const color = darkMode ? "magentaBright" : "magenta";
-  
+
+  if (accessible) {
+    return (
+      <Box flexDirection="column">
+        <Text color={color} bold>PRIMER</Text>
+      </Box>
+    );
+  }
+
   return (
     <Box flexDirection="column">
       {FULL_BANNER.map((line, i) => (

--- a/src/ui/BatchTui.tsx
+++ b/src/ui/BatchTui.tsx
@@ -19,6 +19,7 @@ import { StaticBanner } from "./AnimatedBanner";
 type Props = {
   token: string;
   outputPath?: string;
+  accessible?: boolean;
 };
 
 type Status =
@@ -38,7 +39,7 @@ type ProcessResult = {
   error?: string;
 };
 
-export function BatchTui({ token, outputPath }: Props): React.JSX.Element {
+export function BatchTui({ token, outputPath, accessible = false }: Props): React.JSX.Element {
   const app = useApp();
   const [status, setStatus] = useState<Status>("loading-orgs");
   const [message, setMessage] = useState<string>("Fetching organizations...");
@@ -315,8 +316,8 @@ export function BatchTui({ token, outputPath }: Props): React.JSX.Element {
   };
 
   return (
-    <Box flexDirection="column" padding={1} borderStyle="round">
-      <StaticBanner />
+    <Box flexDirection="column" padding={1} borderStyle={accessible ? undefined : "round"}>
+      <StaticBanner accessible={accessible} />
       <Text color="cyan">Batch Processing - Prime repositories at scale</Text>
       <Box marginTop={1}>
         <Text>{message}</Text>
@@ -338,8 +339,8 @@ export function BatchTui({ token, outputPath }: Props): React.JSX.Element {
               const isCursor = realIndex === cursorIndex;
               return (
                 <Text key={org.login}>
-                  <Text color={isCursor ? "cyan" : undefined}>{isCursor ? "❯ " : "  "}</Text>
-                  <Text color={isSelected ? "green" : "gray"}>{isSelected ? "◉" : "○"} </Text>
+                  <Text color={isCursor ? "cyan" : undefined}>{isCursor ? (accessible ? "> " : "❯ ") : "  "}</Text>
+                  <Text color={isSelected ? "green" : "gray"}>{isSelected ? (accessible ? "[x]" : "◉") : (accessible ? "[ ]" : "○")} </Text>
                   <Text>{org.name ?? org.login}</Text>
                   <Text color="gray"> ({org.login})</Text>
                 </Text>
@@ -364,9 +365,9 @@ export function BatchTui({ token, outputPath }: Props): React.JSX.Element {
               const isCursor = realIndex === cursorIndex;
               return (
                 <Text key={repo.fullName}>
-                  <Text color={isCursor ? "cyan" : undefined}>{isCursor ? "❯ " : "  "}</Text>
-                  <Text color={isSelected ? "green" : "gray"}>{isSelected ? "◉" : "○"} </Text>
-                  <Text color={repo.hasInstructions ? "green" : "red"}>{repo.hasInstructions ? "✓" : "✗"} </Text>
+                  <Text color={isCursor ? "cyan" : undefined}>{isCursor ? (accessible ? "> " : "❯ ") : "  "}</Text>
+                  <Text color={isSelected ? "green" : "gray"}>{isSelected ? (accessible ? "[x]" : "◉") : (accessible ? "[ ]" : "○")} </Text>
+                  <Text color={repo.hasInstructions ? "green" : "red"}>{repo.hasInstructions ? (accessible ? "HAS" : "✓") : (accessible ? "NEEDS" : "✗")} </Text>
                   <Text color={repo.hasInstructions ? "gray" : undefined}>{repo.fullName}</Text>
                   {repo.isPrivate && <Text color="yellow"> (private)</Text>}
                 </Text>
@@ -394,8 +395,8 @@ export function BatchTui({ token, outputPath }: Props): React.JSX.Element {
               <Text color="cyan">Completed:</Text>
               {results.slice(-5).map((r) => (
                 <Text key={r.repo} color={r.success ? "green" : "red"}>
-                  {r.success ? "✓" : "✗"} {r.repo}
-                  {r.success && r.prUrl && <Text color="gray"> → {r.prUrl}</Text>}
+                  {r.success ? (accessible ? "OK" : "✓") : (accessible ? "FAIL" : "✗")} {r.repo}
+                  {r.success && r.prUrl && <Text color="gray"> {accessible ? "- " : "→ "}{r.prUrl}</Text>}
                   {!r.success && r.error && <Text color="gray"> ({r.error})</Text>}
                 </Text>
               ))}
@@ -407,13 +408,13 @@ export function BatchTui({ token, outputPath }: Props): React.JSX.Element {
       {status === "complete" && (
         <Box flexDirection="column" marginTop={1}>
           <Text color="green" bold>
-            ✓ Batch complete: {results.filter(r => r.success).length} succeeded, {results.filter(r => !r.success).length} failed
+            {accessible ? "DONE" : "✓"} Batch complete: {results.filter(r => r.success).length} succeeded, {results.filter(r => !r.success).length} failed
           </Text>
           <Box flexDirection="column" marginTop={1}>
             {results.map((r) => (
               <Text key={r.repo} color={r.success ? "green" : "red"}>
-                {r.success ? "✓" : "✗"} {r.repo}
-                {r.success && r.prUrl && <Text color="gray"> → {r.prUrl}</Text>}
+                {r.success ? (accessible ? "OK" : "✓") : (accessible ? "FAIL" : "✗")} {r.repo}
+                {r.success && r.prUrl && <Text color="gray"> {accessible ? "- " : "→ "}{r.prUrl}</Text>}
                 {!r.success && r.error && <Text color="gray"> ({r.error})</Text>}
               </Text>
             ))}

--- a/src/ui/tui.tsx
+++ b/src/ui/tui.tsx
@@ -12,11 +12,12 @@ import { getGitHubToken } from "../services/github";
 type Props = {
   repoPath: string;
   skipAnimation?: boolean;
+  accessible?: boolean;
 };
 
 type Status = "intro" | "idle" | "analyzing" | "generating" | "evaluating" | "preview" | "done" | "error" | "batch";
 
-export function PrimerTui({ repoPath, skipAnimation = false }: Props): React.JSX.Element {
+export function PrimerTui({ repoPath, skipAnimation = false, accessible = false }: Props): React.JSX.Element {
   const app = useApp();
   const [status, setStatus] = useState<Status>(skipAnimation ? "idle" : "intro");
   const [analysis, setAnalysis] = useState<RepoAnalysis | null>(null);
@@ -161,15 +162,15 @@ export function PrimerTui({ repoPath, skipAnimation = false }: Props): React.JSX
 
   // Render BatchTui when in batch mode
   if (status === "batch" && batchToken) {
-    return <BatchTui token={batchToken} />;
+    return <BatchTui token={batchToken} accessible={accessible} />;
   }
 
   return (
-    <Box flexDirection="column" padding={1} borderStyle="round">
+    <Box flexDirection="column" padding={1} borderStyle={accessible ? undefined : "round"}>
       {status === "intro" ? (
         <AnimatedBanner onComplete={handleAnimationComplete} />
       ) : (
-        <StaticBanner />
+        <StaticBanner accessible={accessible} />
       )}
       <Text color="cyan">Prime your repo for AI.</Text>
       <Text color="gray">Repo: {repoLabel}</Text>
@@ -187,17 +188,17 @@ export function PrimerTui({ repoPath, skipAnimation = false }: Props): React.JSX
         <Text>{message}</Text>
       </Box>
       {status === "preview" && generatedContent && (
-        <Box flexDirection="column" marginTop={1} borderStyle="single" borderColor="gray" paddingX={1}>
+        <Box flexDirection="column" marginTop={1} borderStyle={accessible ? undefined : "single"} borderColor="gray" paddingX={1}>
           <Text color="cyan" bold>Preview (.github/copilot-instructions.md):</Text>
           <Text color="gray">{truncatedPreview}</Text>
         </Box>
       )}
       {evalResults && evalResults.length > 0 && (
-        <Box flexDirection="column" marginTop={1} borderStyle="single" borderColor="gray" paddingX={1}>
+        <Box flexDirection="column" marginTop={1} borderStyle={accessible ? undefined : "single"} borderColor="gray" paddingX={1}>
           <Text color="cyan" bold>Eval Results:</Text>
           {evalResults.map((r) => (
             <Text key={r.id} color={r.verdict === "pass" ? "green" : r.verdict === "fail" ? "red" : "yellow"}>
-              {r.verdict === "pass" ? "✓" : r.verdict === "fail" ? "✗" : "?"} {r.id}: {r.verdict} (score: {r.score})
+              {r.verdict === "pass" ? (accessible ? "PASS" : "✓") : r.verdict === "fail" ? (accessible ? "FAIL" : "✗") : "?"} {r.id}: {r.verdict} (score: {r.score})
             </Text>
           ))}
         </Box>


### PR DESCRIPTION
## Why

I am a blind developer. When I run the Primer TUI with a screen reader, every box-drawing border character gets read aloud individually: "box drawing light arc down and right, box drawing light horizontal, box drawing light horizontal..." over and over. The block-art ASCII banner is even worse. Unicode symbols like checkmarks and bullets also get verbose announcements instead of useful information.

This makes the TUI unusable with a screen reader.

## What this does

Adds a `--accessible` flag that strips out all the visual decoration and replaces it with plain text that screen readers can actually read.

**Borders:** Removed when `--accessible` is on. No more box-drawing characters.

**Banner:** The block-art "PRIMER" banner becomes the word "PRIMER" in plain text.

**Symbols:** Unicode gets replaced with text:
- `✓` becomes `PASS` or `OK`
- `✗` becomes `FAIL`
- `◉` becomes `[x]`
- `○` becomes `[ ]`
- `❯` becomes `>`
- `→` becomes `-`

**Ink integration:** Passes `isScreenReaderEnabled: true` to Ink's `render()` so the framework itself also optimizes output.

## Usage

```bash
# Global flag works with any subcommand
primer --accessible tui
primer --accessible batch

# Or set once via environment variable
export INK_SCREEN_READER=true
primer tui
```

## What a screen reader hears now

**Before:**
> box drawing light arc down and right, box drawing light horizontal, box drawing light horizontal, box drawing light horizontal, box drawing light arc down and left, full block, full block, full block...

**After:**
> PRIMER. Prime your repo for AI. Repo: my-project. Status: ready. Keys: A Analyze, G Generate, E Eval, B Batch, Q Quit.

## Files changed

- `src/cli.ts` — global `--accessible` option
- `src/commands/tui.tsx` — reads flag, passes to render and component
- `src/commands/batch.tsx` — same
- `src/ui/AnimatedBanner.tsx` — plain text banner in accessible mode
- `src/ui/tui.tsx` — conditional borders and text symbols
- `src/ui/BatchTui.tsx` — conditional borders and text symbols for all lists

## Test plan

- [ ] `primer --accessible tui` — no box-drawing characters in output
- [ ] `primer --accessible batch` — no Unicode symbols in lists
- [ ] `INK_SCREEN_READER=true primer tui` — same behavior via env var
- [ ] `primer tui` without flag — normal visual output unchanged
- [ ] Test with a screen reader (VoiceOver, NVDA, JAWS)

🤖 Generated with [Claude Code](https://claude.com/claude-code)