### PR TITLE
Fix instruction generation error: Dynamic require of "util" is not supported

### DIFF
--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -51,7 +51,7 @@ export default defineConfig({
     // Providing a real require via createRequire fixes this for Node built-ins.
     // Use alias (__bannerCreateRequire) to avoid colliding with cli.ts's own
     // `import { createRequire } from "node:module"` in the bundled output.
-    js: '#!/usr/bin/env node\nimport { createRequire as __bannerCreateRequire } from "module";\nconst require = __bannerCreateRequire(import.meta.url);'
+    js: '#!/usr/bin/env node\nimport { createRequire as __bannerCreateRequire } from "node:module";\nconst require = __bannerCreateRequire(import.meta.url);'
   },
   // Keep node_modules as external — they'll be installed via npm
   external: [/^[^./]/],


### PR DESCRIPTION
# Summary

## Repro:
1.) Run: agentrc instructions
2.) Error:
  Generating instructions...
[agentrc:copilot] trying override AGENTRC_COPILOT_CLI_PATH=C:\Users\nicolela\AppData\Roaming\Code\User\globalStorage\github.copilot-chat\copilotCli\copilot.bat  
[agentrc:copilot] override CLI is compatible
[agentrc:copilot] validating CLI compatibility with C:\Users\nicolela\AppData\Roaming\Code\User\globalStorage\github.copilot-chat\copilotCli\copilot.bat
**Error: Failed to generate instructions with Copilot SDK. Ensure the Copilot CLI is installed (copilot --version) and logged in. Dynamic require of "util" is not supported**

## Fix: Add `createRequire` banner to tsup.config.ts

### Problem

When CJS dependencies (e.g. `vscode-jsonrpc`) are bundled into an ESM output, calls to `require()` inside those dependencies fail at runtime with `ReferenceError: require is not defined`. ESM does not provide a global `require` — it only exists in CommonJS.

### Solution

Add a `banner.js` entry in the tsup config that injects a shim at the top of the output bundle. This shim uses Node's built-in `module` package to create a real `require` function.

### Why this works

- `import { createRequire } from "module"` — imports the factory from Node's built-in `module` package.
- `createRequire(import.meta.url)` — creates a CJS-compatible `require()` function anchored to the bundle's file path.
- Bundled CJS code that calls `require("util")`, `require("path")`, etc. now resolves normally.
- The `#!/usr/bin/env node` shebang is included so the bundle is directly executable as a CLI.

This pull request updates the Copilot SDK client creation logic to improve compatibility with Windows and better handle cases where the CLI cannot be executed directly. The main changes clarify when to bypass the SDK-managed process and use the external server mode, specifically for `.bat`/`.cmd` shims and npx wrappers.

# Checklist

- [NA] Tests added or updated
- [x] Lint/typecheck pass
- [NA] Docs updated if needed
