### PR TITLE
fix(ui): prevent terminal screen cheese on TUI resize

### DIFF
--- a/src/ui/tui.tsx
+++ b/src/ui/tui.tsx
@@ -64,6 +64,7 @@ const SPINNER_FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", 
 /** Track terminal columns reactively so resize triggers a re-render. */
 function useTerminalColumns(): number {
   const { stdout } = useStdout();
+  const accessible = useIsScreenReaderEnabled();
   const [columns, setColumns] = useState(stdout.columns ?? 80);
   useEffect(() => {
     const onResize = () => {
@@ -71,7 +72,10 @@ function useTerminalColumns(): number {
       // causing ghost artifacts ("screen cheese"). We use prependListener so
       // this fires BEFORE Ink's own resize handler, clearing the screen
       // before Ink re-renders — avoiding a wasted double-paint.
-      stdout.write("\x1b[2J\x1b[H");
+      // Skip in accessible mode to avoid screen readers announcing escape noise.
+      if (!accessible) {
+        stdout.write("\x1b[2J\x1b[H");
+      }
       setColumns(stdout.columns ?? 80);
     };
     // prependListener ensures our clear runs before Ink's resized() handler,
@@ -81,7 +85,7 @@ function useTerminalColumns(): number {
     return () => {
       stdout.off("resize", onResize);
     };
-  }, [stdout]);
+  }, [stdout, accessible]);
   return columns;
 }
 


### PR DESCRIPTION
## Problem

Resizing the terminal while the TUI is running causes "screen cheese" — old renders stack and overlap instead of being replaced, producing multiple AGENTRC ASCII banners on screen simultaneously.

![Screenshot showing stacked banner artifacts](https://github.com/user-attachments/assets/placeholder)

## Root Cause

Ink 6.x tracks `previousLineCount` in its `log-update` module for cursor math (`eraseLines`, `cursorUp`). When the terminal resizes, the emulator **reflows** existing text — changing how many visual lines the content occupies — but Ink's internal counters stay stale.

Ink's own `resized()` handler only calls `this.log.clear()` on **width decrease**. Width increases and height-only changes leave the stale state in place, causing partial erasure and ghost content on the next render.

## Fix

Clear the visible terminal area (`\x1b[2J\x1b[H`) in the `useTerminalColumns` resize handler, using `prependListener` so it fires **before** Ink's own `resized()`. This ensures Ink re-renders onto a clean slate on every resize direction — no wasted double-paint.

## Details

- Uses `stdout.prependListener("resize", ...)` to run before Ink's handler
- `\x1b[2J` clears the visible area (not scrollback); `\x1b[H` homes the cursor
- Ink's subsequent `resized()` → `onRender()` paints fresh content immediately
- No impact on screen reader mode (separate render path)
- Batch TUIs are unaffected (they don't use `useTerminalColumns`)

## Verification

- ✅ Typecheck passes
- ✅ Lint passes  
- ✅ Build passes
- ✅ All 574 tests pass