### PR TITLE
feat(policy): support native PolicyPlugin exports from module files

### DIFF
--- a/packages/core/src/services/policy.ts
+++ b/packages/core/src/services/policy.ts
@@ -3,6 +3,8 @@ import path from "path";
 
 import { readJson, stripJsonComments } from "../utils/fs";
 
+import type { PolicyPlugin } from "./policy/types";
+import { isNativePlugin, validateNativePlugin } from "./policy/types";
 import type { ReadinessCriterion, ReadinessContext } from "./readiness";
 
 // ─── Policy configuration types ───
@@ -158,10 +160,17 @@ export function parsePolicySources(raw: string | undefined): string[] | undefine
 
 // ─── Loading ───
 
+/**
+ * Load a policy from a file path or npm specifier.
+ *
+ * Returns either a PolicyConfig (for traditional criteria-based policies)
+ * or a PolicyPlugin (for native plugins that export the full plugin contract).
+ * Native plugins are detected by the presence of a `meta` property.
+ */
 export async function loadPolicy(
   source: string,
   options?: { jsonOnly?: boolean }
-): Promise<PolicyConfig> {
+): Promise<PolicyConfig | PolicyPlugin> {
   const jsonOnly = options?.jsonOnly ?? false;
 
   // Local file path (relative or absolute)
@@ -184,6 +193,12 @@ export async function loadPolicy(
       try {
         const mod = (await import(resolved)) as Record<string, unknown>;
         const config = (mod.default ?? mod) as unknown;
+        // Native PolicyPlugin exports have a `meta` property instead of a root-level `name`.
+        // Detect and return them directly without PolicyConfig validation.
+        if (isNativePlugin(config)) {
+          validateNativePlugin(config, source);
+          return config;
+        }
         return validatePolicyConfig(config, source);
       } catch (err) {
         if (
@@ -216,6 +231,11 @@ export async function loadPolicy(
   try {
     const mod = (await import(source)) as Record<string, unknown>;
     const config = (mod.default ?? mod) as unknown;
+    // Native PolicyPlugin exports from npm packages
+    if (isNativePlugin(config)) {
+      validateNativePlugin(config, source);
+      return config;
+    }
     return validatePolicyConfig(config, source);
   } catch (err) {
     const message =

--- a/packages/core/src/services/policy.ts
+++ b/packages/core/src/services/policy.ts
@@ -166,7 +166,14 @@ export function parsePolicySources(raw: string | undefined): string[] | undefine
  *
  * Returns either a PolicyConfig (for traditional criteria-based policies)
  * or a PolicyPlugin (for native plugins that export the full plugin contract).
- * Native plugins are detected by the presence of a `meta` property.
+ * Native plugins are detected via `isNativePlugin()`: they must have a `meta`
+ * object with a non-empty `meta.name` string, and must NOT have a root-level
+ * `name` string (which would indicate a PolicyConfig).
+ *
+ * Note: Native plugin exports may omit `meta.sourceType` and `meta.trust`.
+ * The loader in `loadPluginChain()` normalises these to "module" and
+ * "trusted-code" respectively before adding the plugin to the chain.
+ * Callers should not access these fields on the raw return value.
  */
 export async function loadPolicy(
   source: string,

--- a/packages/core/src/services/policy.ts
+++ b/packages/core/src/services/policy.ts
@@ -1,5 +1,6 @@
 import fs from "fs/promises";
 import path from "path";
+import { pathToFileURL } from "url";
 
 import { readJson, stripJsonComments } from "../utils/fs";
 
@@ -191,7 +192,10 @@ export async function loadPolicy(
         );
       }
       try {
-        const mod = (await import(resolved)) as Record<string, unknown>;
+        // Use pathToFileURL to convert filesystem paths to file:// URLs.
+        // On Windows, path.resolve() returns paths like C:\... which dynamic
+        // import() treats as a URL scheme (c:), causing ERR_UNSUPPORTED_ESM_URL_SCHEME.
+        const mod = (await import(pathToFileURL(resolved).href)) as Record<string, unknown>;
         const config = (mod.default ?? mod) as unknown;
         // Native PolicyPlugin exports have a `meta` property instead of a root-level `name`.
         // Detect and return them directly without PolicyConfig validation.

--- a/packages/core/src/services/policy/index.ts
+++ b/packages/core/src/services/policy/index.ts
@@ -19,7 +19,7 @@ export type {
   EngineReport,
   Grade
 } from "./types";
-export { calculateScore } from "./types";
+export { calculateScore, isNativePlugin, validateNativePlugin } from "./types";
 export { executePlugins } from "./engine";
 export type { EngineOptions } from "./engine";
 export { compilePolicyConfig } from "./compiler";

--- a/packages/core/src/services/policy/loader.ts
+++ b/packages/core/src/services/policy/loader.ts
@@ -20,6 +20,7 @@ import { compilePolicyConfig } from "./compiler";
 import type { CompilationResult } from "./compiler";
 import type { EngineOptions } from "./engine";
 import type { PolicyPlugin } from "./types";
+import { isNativePlugin } from "./types";
 
 export type LoadedChain = {
   plugins: PolicyPlugin[];
@@ -80,9 +81,26 @@ export async function loadPluginChain(
   let passRateThreshold = 0.8;
 
   for (const source of policySources) {
-    const policyConfig: PolicyConfig = await loadPolicy(source, {
+    const loaded = await loadPolicy(source, {
       jsonOnly: options?.jsonOnly
     });
+
+    // Native PolicyPlugin exports — use directly with trusted-code trust.
+    // These modules export the full plugin contract (detectors, hooks, recommenders)
+    // instead of the PolicyConfig DSL (criteria.add/disable/override).
+    if (isNativePlugin(loaded)) {
+      plugins.push({
+        ...loaded,
+        meta: {
+          ...loaded.meta,
+          sourceType: "module",
+          trust: "trusted-code"
+        }
+      });
+      continue;
+    }
+
+    const policyConfig: PolicyConfig = loaded;
 
     // Check if this is a module policy (imperative plugin) with code-level hooks
     if (isImperativePlugin(policyConfig)) {

--- a/packages/core/src/services/policy/types.ts
+++ b/packages/core/src/services/policy/types.ts
@@ -157,6 +157,47 @@ export type PolicyPlugin = {
   onError?: (error: Error, stage: PluginStage, ctx: PolicyContext) => boolean;
 };
 
+// ─── Type guards ───
+
+/**
+ * Detect whether a loaded module export is a native PolicyPlugin.
+ *
+ * Native plugins export a `PolicyPlugin` object directly (with a `meta` property)
+ * instead of a `PolicyConfig` object (which has a top-level `name` string).
+ * This allows module authors to use the full plugin lifecycle API
+ * (afterDetect, beforeRecommend, afterRecommend hooks with SignalPatch/RecommendationPatch)
+ * rather than being limited to the criteria.add/disable/override DSL.
+ */
+export function isNativePlugin(obj: unknown): obj is PolicyPlugin {
+  if (typeof obj !== "object" || obj === null) return false;
+  const record = obj as Record<string, unknown>;
+  if (typeof record.meta !== "object" || record.meta === null) return false;
+  const meta = record.meta as Record<string, unknown>;
+  return typeof meta.name === "string" && meta.name.trim().length > 0;
+}
+
+/**
+ * Validate that a native plugin export has the minimum required structure.
+ * Throws descriptive errors for invalid plugins.
+ */
+export function validateNativePlugin(obj: PolicyPlugin, source: string): void {
+  const { meta } = obj;
+  if (!meta.name?.trim()) {
+    throw new Error(`Native plugin "${source}" is invalid: meta.name is required`);
+  }
+  const hasHooks =
+    obj.detectors?.length ||
+    obj.afterDetect ||
+    obj.beforeRecommend ||
+    obj.recommenders?.length ||
+    obj.afterRecommend;
+  if (!hasHooks) {
+    throw new Error(
+      `Native plugin "${source}" is invalid: must implement at least one hook (detectors, afterDetect, beforeRecommend, recommenders, or afterRecommend)`
+    );
+  }
+}
+
 // ─── Engine output ───
 
 /** Grade label for a readiness score. */

--- a/packages/core/src/services/policy/types.ts
+++ b/packages/core/src/services/policy/types.ts
@@ -173,7 +173,9 @@ export function isNativePlugin(obj: unknown): obj is PolicyPlugin {
   const record = obj as Record<string, unknown>;
   if (typeof record.meta !== "object" || record.meta === null) return false;
   const meta = record.meta as Record<string, unknown>;
-  return typeof meta.name === "string" && meta.name.trim().length > 0;
+  return (
+    typeof meta.name === "string" && meta.name.trim().length > 0 && typeof record.name !== "string"
+  );
 }
 
 /**

--- a/packages/core/src/services/policy/types.ts
+++ b/packages/core/src/services/policy/types.ts
@@ -162,31 +162,109 @@ export type PolicyPlugin = {
 /**
  * Detect whether a loaded module export is a native PolicyPlugin.
  *
- * Native plugins export a `PolicyPlugin` object directly (with a `meta` property)
- * instead of a `PolicyConfig` object (which has a top-level `name` string).
- * This allows module authors to use the full plugin lifecycle API
- * (afterDetect, beforeRecommend, afterRecommend hooks with SignalPatch/RecommendationPatch)
- * rather than being limited to the criteria.add/disable/override DSL.
+ * Detection rules:
+ * 1. Must have a `meta` object with a non-empty `meta.name` string
+ * 2. Must NOT have a root-level `name` string (which would indicate a PolicyConfig)
+ * 3. If `meta.sourceType` or `meta.trust` are provided, they must be valid values
+ *
+ * Note: This is a detection heuristic, not a full validation. The loader normalises
+ * `meta.sourceType` and `meta.trust` after detection (overriding with "module" and
+ * "trusted-code"), so these fields are optional in the module export.
+ * Use `validateNativePlugin()` after detection to verify the plugin has valid hooks.
  */
 export function isNativePlugin(obj: unknown): obj is PolicyPlugin {
   if (typeof obj !== "object" || obj === null) return false;
   const record = obj as Record<string, unknown>;
   if (typeof record.meta !== "object" || record.meta === null) return false;
+  if (typeof record.name === "string") return false;
   const meta = record.meta as Record<string, unknown>;
-  return (
-    typeof meta.name === "string" && meta.name.trim().length > 0 && typeof record.name !== "string"
-  );
+  if (typeof meta.name !== "string" || meta.name.trim().length === 0) return false;
+  // Reject if meta fields are present but invalid
+  if (
+    meta.sourceType !== undefined &&
+    !["module", "json", "builtin"].includes(meta.sourceType as string)
+  )
+    return false;
+  if (
+    meta.trust !== undefined &&
+    !["trusted-code", "safe-declarative"].includes(meta.trust as string)
+  )
+    return false;
+  return true;
 }
 
 /**
  * Validate that a native plugin export has the minimum required structure.
- * Throws descriptive errors for invalid plugins.
+ * Checks that hooks are the correct types and that detector/recommender arrays
+ * contain objects with the expected callable members.
+ * Throws descriptive errors for invalid plugins so issues are caught at load time.
  */
 export function validateNativePlugin(obj: PolicyPlugin, source: string): void {
   const { meta } = obj;
   if (!meta.name?.trim()) {
     throw new Error(`Native plugin "${source}" is invalid: meta.name is required`);
   }
+
+  // Validate hook functions
+  if (obj.afterDetect !== undefined && typeof obj.afterDetect !== "function") {
+    throw new Error(`Native plugin "${source}" is invalid: afterDetect must be a function`);
+  }
+  if (obj.beforeRecommend !== undefined && typeof obj.beforeRecommend !== "function") {
+    throw new Error(`Native plugin "${source}" is invalid: beforeRecommend must be a function`);
+  }
+  if (obj.afterRecommend !== undefined && typeof obj.afterRecommend !== "function") {
+    throw new Error(`Native plugin "${source}" is invalid: afterRecommend must be a function`);
+  }
+  if (obj.onError !== undefined && typeof obj.onError !== "function") {
+    throw new Error(`Native plugin "${source}" is invalid: onError must be a function`);
+  }
+
+  // Validate detector array members
+  if (obj.detectors !== undefined) {
+    if (!Array.isArray(obj.detectors)) {
+      throw new Error(`Native plugin "${source}" is invalid: detectors must be an array`);
+    }
+    for (const [i, d] of obj.detectors.entries()) {
+      if (typeof d !== "object" || d === null) {
+        throw new Error(`Native plugin "${source}" is invalid: detectors[${i}] must be an object`);
+      }
+      if (typeof d.id !== "string" || !d.id.trim()) {
+        throw new Error(
+          `Native plugin "${source}" is invalid: detectors[${i}].id must be a non-empty string`
+        );
+      }
+      if (typeof d.detect !== "function") {
+        throw new Error(
+          `Native plugin "${source}" is invalid: detectors[${i}].detect must be a function`
+        );
+      }
+    }
+  }
+
+  // Validate recommender array members
+  if (obj.recommenders !== undefined) {
+    if (!Array.isArray(obj.recommenders)) {
+      throw new Error(`Native plugin "${source}" is invalid: recommenders must be an array`);
+    }
+    for (const [i, r] of obj.recommenders.entries()) {
+      if (typeof r !== "object" || r === null) {
+        throw new Error(
+          `Native plugin "${source}" is invalid: recommenders[${i}] must be an object`
+        );
+      }
+      if (typeof r.id !== "string" || !r.id.trim()) {
+        throw new Error(
+          `Native plugin "${source}" is invalid: recommenders[${i}].id must be a non-empty string`
+        );
+      }
+      if (typeof r.recommend !== "function") {
+        throw new Error(
+          `Native plugin "${source}" is invalid: recommenders[${i}].recommend must be a function`
+        );
+      }
+    }
+  }
+
   const hasHooks =
     obj.detectors?.length ||
     obj.afterDetect ||

--- a/packages/core/src/services/readiness/index.ts
+++ b/packages/core/src/services/readiness/index.ts
@@ -7,6 +7,7 @@ import { loadPolicy, resolveChain } from "../policy";
 import { executePlugins } from "../policy/engine";
 import { loadPluginChain } from "../policy/loader";
 import type { PolicyContext } from "../policy/types";
+import { isNativePlugin } from "../policy/types";
 
 import { parseVscodeLocations } from "./checkers";
 import { buildCriteria } from "./criteria";
@@ -91,7 +92,16 @@ export async function runReadinessReport(options: ReadinessOptions): Promise<Rea
   if (policySources?.length) {
     const policyConfigs: PolicyConfig[] = [];
     for (const source of policySources) {
-      policyConfigs.push(await loadPolicy(source, { jsonOnly: isConfigSourced }));
+      const loaded = await loadPolicy(source, { jsonOnly: isConfigSourced });
+      // Native PolicyPlugin exports require the engine path (loadPluginChain + executePlugins).
+      // The legacy resolveChain path only supports PolicyConfig objects.
+      if (isNativePlugin(loaded)) {
+        throw new Error(
+          `Policy "${source}" exports a native PolicyPlugin and cannot be used with the legacy criteria path. ` +
+            `Native plugins are supported through the plugin engine — this is an internal error.`
+        );
+      }
+      policyConfigs.push(loaded);
     }
     const resolved = resolveChain(baseCriteria, baseExtras, policyConfigs);
     resolvedCriteria = resolved.criteria;

--- a/packages/core/src/services/readiness/index.ts
+++ b/packages/core/src/services/readiness/index.ts
@@ -97,8 +97,8 @@ export async function runReadinessReport(options: ReadinessOptions): Promise<Rea
       // The legacy resolveChain path only supports PolicyConfig objects.
       if (isNativePlugin(loaded)) {
         throw new Error(
-          `Policy "${source}" exports a native PolicyPlugin and cannot be used with the legacy criteria path. ` +
-            `Native plugins are supported through the plugin engine — this is an internal error.`
+          `Policy "${source}" exports a native PolicyPlugin, which is only supported via the plugin engine path. ` +
+            `The legacy readiness criteria path used for --policies only supports PolicyConfig objects.`
         );
       }
       policyConfigs.push(loaded);

--- a/packages/core/src/services/readiness/index.ts
+++ b/packages/core/src/services/readiness/index.ts
@@ -91,23 +91,33 @@ export async function runReadinessReport(options: ReadinessOptions): Promise<Rea
 
   if (policySources?.length) {
     const policyConfigs: PolicyConfig[] = [];
+    let hasNativePlugin = false;
     for (const source of policySources) {
       const loaded = await loadPolicy(source, { jsonOnly: isConfigSourced });
-      // Native PolicyPlugin exports require the engine path (loadPluginChain + executePlugins).
-      // The legacy resolveChain path only supports PolicyConfig objects.
+      // Native PolicyPlugin exports are handled by the engine path (loadPluginChain).
+      // Skip them here — they'll be loaded by loadPluginChain below.
       if (isNativePlugin(loaded)) {
-        throw new Error(
-          `Policy "${source}" exports a native PolicyPlugin, which is only supported via the plugin engine path. ` +
-            `The legacy readiness criteria path used for --policies only supports PolicyConfig objects.`
-        );
+        hasNativePlugin = true;
+        continue;
       }
       policyConfigs.push(loaded);
     }
-    const resolved = resolveChain(baseCriteria, baseExtras, policyConfigs);
-    resolvedCriteria = resolved.criteria;
-    resolvedExtras = resolved.extras;
-    passRateThreshold = resolved.thresholds.passRate;
-    policyInfo = { chain: resolved.chain, criteriaCount: resolved.criteria.length };
+    if (policyConfigs.length > 0) {
+      const resolved = resolveChain(baseCriteria, baseExtras, policyConfigs);
+      resolvedCriteria = resolved.criteria;
+      resolvedExtras = resolved.extras;
+      passRateThreshold = resolved.thresholds.passRate;
+      policyInfo = { chain: resolved.chain, criteriaCount: resolved.criteria.length };
+    } else {
+      resolvedCriteria = baseCriteria;
+      resolvedExtras = baseExtras;
+    }
+    // When native plugins are present, automatically enable the engine path
+    // so their detectors, hooks, and recommenders execute.
+    // Use a local copy to avoid mutating the caller's options object.
+    if (hasNativePlugin && !options.shadow) {
+      options = { ...options, shadow: true };
+    }
   } else {
     resolvedCriteria = baseCriteria;
     resolvedExtras = baseExtras;

--- a/src/services/__tests__/policy-engine-types.test.ts
+++ b/src/services/__tests__/policy-engine-types.test.ts
@@ -2,13 +2,16 @@ import type {
   Signal,
   Recommendation,
   SignalPatch,
-  RecommendationPatch
+  RecommendationPatch,
+  PolicyPlugin
 } from "@agentrc/core/services/policy/types";
 import {
   calculateScore,
   applySignalPatch,
   applyRecommendationPatch,
-  resolveSupersedes
+  resolveSupersedes,
+  isNativePlugin,
+  validateNativePlugin
 } from "@agentrc/core/services/policy/types";
 import { describe, expect, it } from "vitest";
 
@@ -413,5 +416,119 @@ describe("resolveSupersedes", () => {
     const result = resolveSupersedes(recs);
     expect(result).toHaveLength(1);
     expect(result[0].origin.modifiedBy).toBeUndefined();
+  });
+});
+
+// ─── isNativePlugin ───
+
+describe("isNativePlugin", () => {
+  it("returns true for an object with meta.name", () => {
+    const plugin: PolicyPlugin = {
+      meta: { name: "test-plugin", sourceType: "module", trust: "trusted-code" },
+      detectors: [
+        {
+          id: "d1",
+          kind: "file",
+          detect: async () => ({
+            id: "s1",
+            kind: "file" as const,
+            status: "detected" as const,
+            label: "S1",
+            origin: { addedBy: "test" }
+          })
+        }
+      ]
+    };
+    expect(isNativePlugin(plugin)).toBe(true);
+  });
+
+  it("returns false for a PolicyConfig object (has root-level name)", () => {
+    const config = { name: "my-policy", criteria: { disable: ["readme"] } };
+    expect(isNativePlugin(config)).toBe(false);
+  });
+
+  it("returns false for null", () => {
+    expect(isNativePlugin(null)).toBe(false);
+  });
+
+  it("returns false for undefined", () => {
+    expect(isNativePlugin(undefined)).toBe(false);
+  });
+
+  it("returns false for a string", () => {
+    expect(isNativePlugin("not a plugin")).toBe(false);
+  });
+
+  it("returns false for an object with meta but no meta.name", () => {
+    expect(isNativePlugin({ meta: { sourceType: "module" } })).toBe(false);
+  });
+
+  it("returns false for an object with meta.name that is empty", () => {
+    expect(isNativePlugin({ meta: { name: "  " } })).toBe(false);
+  });
+
+  it("returns false for an object with meta as a non-object", () => {
+    expect(isNativePlugin({ meta: "not-an-object" })).toBe(false);
+  });
+
+  it("returns false for an object with meta as null", () => {
+    expect(isNativePlugin({ meta: null })).toBe(false);
+  });
+});
+
+// ─── validateNativePlugin ───
+
+describe("validateNativePlugin", () => {
+  it("does not throw for a valid native plugin with detectors", () => {
+    const plugin: PolicyPlugin = {
+      meta: { name: "valid", sourceType: "module", trust: "trusted-code" },
+      detectors: [
+        {
+          id: "d1",
+          kind: "file",
+          detect: async () => ({
+            id: "s1",
+            kind: "file" as const,
+            status: "detected" as const,
+            label: "S1",
+            origin: { addedBy: "test" }
+          })
+        }
+      ]
+    };
+    expect(() => validateNativePlugin(plugin, "test.mjs")).not.toThrow();
+  });
+
+  it("does not throw for a valid native plugin with only afterDetect", () => {
+    const plugin: PolicyPlugin = {
+      meta: { name: "hook-only", sourceType: "module", trust: "trusted-code" },
+      afterDetect: async () => undefined
+    };
+    expect(() => validateNativePlugin(plugin, "hook.mjs")).not.toThrow();
+  });
+
+  it("does not throw for a valid native plugin with only afterRecommend", () => {
+    const plugin: PolicyPlugin = {
+      meta: { name: "rec-hook", sourceType: "module", trust: "trusted-code" },
+      afterRecommend: async () => undefined
+    };
+    expect(() => validateNativePlugin(plugin, "rec.mjs")).not.toThrow();
+  });
+
+  it("throws for a plugin with no hooks at all", () => {
+    const plugin: PolicyPlugin = {
+      meta: { name: "empty", sourceType: "module", trust: "trusted-code" }
+    };
+    expect(() => validateNativePlugin(plugin, "empty.mjs")).toThrow(
+      "must implement at least one hook"
+    );
+  });
+
+  it("throws for a plugin with empty meta.name", () => {
+    const plugin = {
+      meta: { name: "", sourceType: "module", trust: "trusted-code" },
+      afterDetect: async () => undefined
+    } as PolicyPlugin;
+    expect(() => validateNativePlugin(plugin, "bad.mjs")).toThrow("meta.name is required");
   });
 });

--- a/src/services/__tests__/policy-engine-types.test.ts
+++ b/src/services/__tests__/policy-engine-types.test.ts
@@ -474,6 +474,24 @@ describe("isNativePlugin", () => {
   it("returns false for an object with meta as null", () => {
     expect(isNativePlugin({ meta: null })).toBe(false);
   });
+
+  it("returns false for an object with invalid meta.sourceType", () => {
+    expect(isNativePlugin({ meta: { name: "test", sourceType: "invalid" } })).toBe(false);
+  });
+
+  it("returns false for an object with invalid meta.trust", () => {
+    expect(isNativePlugin({ meta: { name: "test", trust: "invalid" } })).toBe(false);
+  });
+
+  it("returns true when meta.sourceType and meta.trust are valid", () => {
+    expect(
+      isNativePlugin({ meta: { name: "test", sourceType: "module", trust: "trusted-code" } })
+    ).toBe(true);
+  });
+
+  it("returns true when meta.sourceType and meta.trust are omitted", () => {
+    expect(isNativePlugin({ meta: { name: "test" } })).toBe(true);
+  });
 });
 
 // ─── validateNativePlugin ───
@@ -530,5 +548,110 @@ describe("validateNativePlugin", () => {
       afterDetect: async () => undefined
     } as PolicyPlugin;
     expect(() => validateNativePlugin(plugin, "bad.mjs")).toThrow("meta.name is required");
+  });
+
+  it("throws for a plugin with afterDetect that is not a function", () => {
+    const plugin = {
+      meta: { name: "bad", sourceType: "module", trust: "trusted-code" },
+      afterDetect: "not a function"
+    } as unknown as PolicyPlugin;
+    expect(() => validateNativePlugin(plugin, "bad.mjs")).toThrow("afterDetect must be a function");
+  });
+
+  it("throws for a plugin with beforeRecommend that is not a function", () => {
+    const plugin = {
+      meta: { name: "bad", sourceType: "module", trust: "trusted-code" },
+      beforeRecommend: 42
+    } as unknown as PolicyPlugin;
+    expect(() => validateNativePlugin(plugin, "bad.mjs")).toThrow(
+      "beforeRecommend must be a function"
+    );
+  });
+
+  it("throws for a plugin with afterRecommend that is not a function", () => {
+    const plugin = {
+      meta: { name: "bad", sourceType: "module", trust: "trusted-code" },
+      afterRecommend: {}
+    } as unknown as PolicyPlugin;
+    expect(() => validateNativePlugin(plugin, "bad.mjs")).toThrow(
+      "afterRecommend must be a function"
+    );
+  });
+
+  it("throws for a plugin with detectors that is not an array", () => {
+    const plugin = {
+      meta: { name: "bad", sourceType: "module", trust: "trusted-code" },
+      detectors: "not-an-array"
+    } as unknown as PolicyPlugin;
+    expect(() => validateNativePlugin(plugin, "bad.mjs")).toThrow("detectors must be an array");
+  });
+
+  it("throws for a detector entry that is null", () => {
+    const plugin = {
+      meta: { name: "bad", sourceType: "module", trust: "trusted-code" },
+      detectors: [null]
+    } as unknown as PolicyPlugin;
+    expect(() => validateNativePlugin(plugin, "bad.mjs")).toThrow("detectors[0] must be an object");
+  });
+
+  it("throws for a recommender entry that is a primitive", () => {
+    const plugin = {
+      meta: { name: "bad", sourceType: "module", trust: "trusted-code" },
+      recommenders: ["not-an-object"]
+    } as unknown as PolicyPlugin;
+    expect(() => validateNativePlugin(plugin, "bad.mjs")).toThrow(
+      "recommenders[0] must be an object"
+    );
+  });
+
+  it("throws for a detector missing an id", () => {
+    const plugin = {
+      meta: { name: "bad", sourceType: "module", trust: "trusted-code" },
+      detectors: [
+        {
+          kind: "file",
+          detect: async () => ({
+            id: "s",
+            kind: "file",
+            status: "detected",
+            label: "S",
+            origin: { addedBy: "t" }
+          })
+        }
+      ]
+    } as unknown as PolicyPlugin;
+    expect(() => validateNativePlugin(plugin, "bad.mjs")).toThrow(
+      "detectors[0].id must be a non-empty string"
+    );
+  });
+
+  it("throws for a detector with detect that is not a function", () => {
+    const plugin = {
+      meta: { name: "bad", sourceType: "module", trust: "trusted-code" },
+      detectors: [{ id: "d1", kind: "file", detect: "not-a-function" }]
+    } as unknown as PolicyPlugin;
+    expect(() => validateNativePlugin(plugin, "bad.mjs")).toThrow(
+      "detectors[0].detect must be a function"
+    );
+  });
+
+  it("throws for a recommender missing an id", () => {
+    const plugin = {
+      meta: { name: "bad", sourceType: "module", trust: "trusted-code" },
+      recommenders: [{ recommend: async () => [] }]
+    } as unknown as PolicyPlugin;
+    expect(() => validateNativePlugin(plugin, "bad.mjs")).toThrow(
+      "recommenders[0].id must be a non-empty string"
+    );
+  });
+
+  it("throws for a recommender with recommend that is not a function", () => {
+    const plugin = {
+      meta: { name: "bad", sourceType: "module", trust: "trusted-code" },
+      recommenders: [{ id: "r1", recommend: 42 }]
+    } as unknown as PolicyPlugin;
+    expect(() => validateNativePlugin(plugin, "bad.mjs")).toThrow(
+      "recommenders[0].recommend must be a function"
+    );
   });
 });

--- a/src/services/__tests__/policy-loader.test.ts
+++ b/src/services/__tests__/policy-loader.test.ts
@@ -1,6 +1,7 @@
 import fs from "fs/promises";
 import os from "os";
 import path from "path";
+import { pathToFileURL } from "url";
 
 import { executePlugins } from "@agentrc/core/services/policy/engine";
 import { buildBuiltinPlugin, loadPluginChain } from "@agentrc/core/services/policy/loader";
@@ -123,5 +124,185 @@ describe("loadPluginChain with JSON policy file", () => {
     // file-based path always resolves to safe-declarative trust — load should succeed
     const chain = await loadPluginChain([policyPath], { jsonOnly: true });
     expect(chain.plugins[1].meta.trust).toBe("safe-declarative");
+  });
+});
+
+describe("loadPluginChain with native PolicyPlugin module", () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "agentrc-native-"));
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it("loads a native PolicyPlugin with afterDetect hook as trusted-code", async () => {
+    const pluginCode = `
+      export default {
+        meta: { name: "native-hook", sourceType: "module", trust: "trusted-code" },
+        afterDetect: async (signals) => ({
+          modify: signals
+            .filter(s => s.id === "readme")
+            .map(s => ({ id: s.id, changes: { label: "Patched by native" } }))
+        })
+      };
+    `;
+    const pluginPath = path.join(tmpDir, "native-hook.mjs");
+    await fs.writeFile(pluginPath, pluginCode);
+
+    const chain = await loadPluginChain([pluginPath]);
+    expect(chain.plugins).toHaveLength(2);
+    expect(chain.plugins[0].meta.name).toBe("builtin");
+    expect(chain.plugins[1].meta.name).toBe("native-hook");
+    expect(chain.plugins[1].meta.sourceType).toBe("module");
+    expect(chain.plugins[1].meta.trust).toBe("trusted-code");
+    expect(chain.plugins[1].afterDetect).toBeDefined();
+  });
+
+  it("loads a native PolicyPlugin with detectors and recommenders", async () => {
+    const pluginCode = `
+      export default {
+        meta: { name: "native-full", sourceType: "module", trust: "trusted-code" },
+        detectors: [{
+          id: "custom-check",
+          kind: "custom",
+          detect: async (ctx) => ({
+            id: "custom-signal",
+            kind: "custom",
+            status: "detected",
+            label: "Custom detection",
+            origin: { addedBy: "native-full" }
+          })
+        }],
+        recommenders: [{
+          id: "custom-rec",
+          recommend: async (signals) => {
+            const s = signals.find(s => s.id === "custom-signal");
+            if (!s) return [];
+            return {
+              id: "custom-fix",
+              signalId: "custom-signal",
+              impact: "high",
+              message: "Fix this custom issue",
+              origin: { addedBy: "native-full" }
+            };
+          }
+        }]
+      };
+    `;
+    const pluginPath = path.join(tmpDir, "native-full.mjs");
+    await fs.writeFile(pluginPath, pluginCode);
+
+    const chain = await loadPluginChain([pluginPath]);
+    expect(chain.plugins).toHaveLength(2);
+    expect(chain.plugins[1].detectors).toHaveLength(1);
+    expect(chain.plugins[1].recommenders).toHaveLength(1);
+  });
+
+  it("executes native plugin hooks through the engine pipeline", async () => {
+    const pluginCode = `
+      export default {
+        meta: { name: "engine-test", sourceType: "module", trust: "trusted-code" },
+        detectors: [{
+          id: "native-detector",
+          kind: "custom",
+          detect: async () => ({
+            id: "native-signal",
+            kind: "custom",
+            status: "detected",
+            label: "Native",
+            origin: { addedBy: "engine-test" }
+          })
+        }],
+        afterDetect: async (signals) => ({
+          modify: signals
+            .filter(s => s.id === "native-signal")
+            .map(s => ({ id: s.id, changes: { label: "Patched", metadata: { patched: true } } }))
+        }),
+        recommenders: [{
+          id: "native-recommender",
+          recommend: async (signals) => {
+            const s = signals.find(s => s.id === "native-signal");
+            if (!s || !s.metadata?.patched) return [];
+            return {
+              id: "native-rec",
+              signalId: "native-signal",
+              impact: "medium",
+              message: "Native recommendation after patch",
+              origin: { addedBy: "engine-test" }
+            };
+          }
+        }]
+      };
+    `;
+    const pluginPath = path.join(tmpDir, "engine-test.mjs");
+    await fs.writeFile(pluginPath, pluginCode);
+
+    const chain = await loadPluginChain([pluginPath]);
+    const report = await executePlugins(chain.plugins, makeCtx());
+
+    const nativeSignal = report.signals.find((s) => s.id === "native-signal");
+    expect(nativeSignal).toBeDefined();
+    expect(nativeSignal!.label).toBe("Patched");
+    expect(nativeSignal!.metadata?.patched).toBe(true);
+
+    const nativeRec = report.recommendations.find((r) => r.id === "native-rec");
+    expect(nativeRec).toBeDefined();
+    expect(nativeRec!.message).toBe("Native recommendation after patch");
+  });
+
+  it("rejects native plugin with no hooks", async () => {
+    const pluginCode = `
+      export default {
+        meta: { name: "empty-plugin", sourceType: "module", trust: "trusted-code" }
+      };
+    `;
+    const pluginPath = path.join(tmpDir, "empty.mjs");
+    await fs.writeFile(pluginPath, pluginCode);
+
+    await expect(loadPluginChain([pluginPath])).rejects.toThrow("must implement at least one hook");
+  });
+
+  it("forces sourceType to module and trust to trusted-code regardless of export values", async () => {
+    const pluginCode = `
+      export default {
+        meta: { name: "override-test", sourceType: "json", trust: "safe-declarative" },
+        afterDetect: async () => undefined
+      };
+    `;
+    const pluginPath = path.join(tmpDir, "override.mjs");
+    await fs.writeFile(pluginPath, pluginCode);
+
+    const chain = await loadPluginChain([pluginPath]);
+    // Loader overrides sourceType and trust for security
+    expect(chain.plugins[1].meta.sourceType).toBe("module");
+    expect(chain.plugins[1].meta.trust).toBe("trusted-code");
+  });
+
+  it("loads native plugin alongside a JSON policy", async () => {
+    const jsonPath = path.join(tmpDir, "config.json");
+    await fs.writeFile(
+      jsonPath,
+      JSON.stringify({ name: "json-policy", criteria: { disable: ["readme"] } })
+    );
+
+    const nativeCode = `
+      export default {
+        meta: { name: "native-policy", sourceType: "module", trust: "trusted-code" },
+        afterDetect: async () => undefined
+      };
+    `;
+    const nativePath = path.join(tmpDir, "native.mjs");
+    await fs.writeFile(nativePath, nativeCode);
+
+    const chain = await loadPluginChain([jsonPath, nativePath]);
+    expect(chain.plugins).toHaveLength(3);
+    expect(chain.plugins[0].meta.name).toBe("builtin");
+    expect(chain.plugins[1].meta.name).toBe("json-policy");
+    expect(chain.plugins[1].meta.trust).toBe("safe-declarative");
+    expect(chain.plugins[2].meta.name).toBe("native-policy");
+    expect(chain.plugins[2].meta.trust).toBe("trusted-code");
   });
 });

--- a/src/services/__tests__/policy-loader.test.ts
+++ b/src/services/__tests__/policy-loader.test.ts
@@ -1,7 +1,6 @@
 import fs from "fs/promises";
 import os from "os";
 import path from "path";
-import { pathToFileURL } from "url";
 
 import { executePlugins } from "@agentrc/core/services/policy/engine";
 import { buildBuiltinPlugin, loadPluginChain } from "@agentrc/core/services/policy/loader";

--- a/src/services/__tests__/policy.test.ts
+++ b/src/services/__tests__/policy.test.ts
@@ -4,8 +4,21 @@ import path from "path";
 
 import type { ExtraDefinition, PolicyConfig } from "@agentrc/core/services/policy";
 import { loadPolicy, resolveChain, parsePolicySources } from "@agentrc/core/services/policy";
+import { isNativePlugin } from "@agentrc/core/services/policy/types";
 import type { ReadinessCriterion } from "@agentrc/core/services/readiness";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+/** Helper: load a policy and assert it is a PolicyConfig (not a native plugin). */
+async function loadPolicyConfig(
+  source: string,
+  options?: { jsonOnly?: boolean }
+): Promise<PolicyConfig> {
+  const result = await loadPolicy(source, options);
+  if (isNativePlugin(result)) {
+    throw new Error(`Expected PolicyConfig but got native PolicyPlugin from "${source}"`);
+  }
+  return result;
+}
 
 // ─── Helpers ───
 
@@ -240,14 +253,14 @@ describe("loadPolicy", () => {
       thresholds: { passRate: 0.9 }
     });
 
-    const config = await loadPolicy(filePath);
+    const config = await loadPolicyConfig(filePath);
     expect(config.name).toBe("my-policy");
     expect(config.thresholds?.passRate).toBe(0.9);
   });
 
   it("loads a minimal JSON policy (name only)", async () => {
     const filePath = await writePolicy("minimal.json", { name: "minimal" });
-    const config = await loadPolicy(filePath);
+    const config = await loadPolicyConfig(filePath);
     expect(config.name).toBe("minimal");
   });
 
@@ -257,7 +270,7 @@ describe("loadPolicy", () => {
       criteria: { disable: ["lint-config", "readme"] }
     });
 
-    const config = await loadPolicy(filePath);
+    const config = await loadPolicyConfig(filePath);
     expect(config.criteria?.disable).toEqual(["lint-config", "readme"]);
   });
 
@@ -383,7 +396,7 @@ describe("loadPolicy", () => {
   it("loads JSON policy via absolute path", async () => {
     const filePath = path.join(tmpDir, "abs-policy.json");
     await fs.writeFile(filePath, JSON.stringify({ name: "absolute" }), "utf8");
-    const config = await loadPolicy(filePath);
+    const config = await loadPolicyConfig(filePath);
     expect(config.name).toBe("absolute");
   });
 
@@ -419,7 +432,7 @@ describe("loadPolicy", () => {
         }
       }
     });
-    const config = await loadPolicy(filePath);
+    const config = await loadPolicyConfig(filePath);
     expect(config.criteria?.override?.a).toEqual({
       title: "New",
       pillar: "testing",
@@ -433,7 +446,7 @@ describe("loadPolicy", () => {
   it("loads a .mjs module policy", async () => {
     const filePath = path.join(tmpDir, "mod-policy.mjs");
     await fs.writeFile(filePath, `export default { name: "mjs-policy", criteria: {} };\n`, "utf8");
-    const config = await loadPolicy(filePath);
+    const config = await loadPolicyConfig(filePath);
     expect(config.name).toBe("mjs-policy");
   });
 });
@@ -454,7 +467,7 @@ describe("loadPolicy jsonOnly", () => {
   it("allows JSON policies when jsonOnly is true", async () => {
     const filePath = path.join(tmpDir, "ok.json");
     await fs.writeFile(filePath, JSON.stringify({ name: "ok" }), "utf8");
-    const config = await loadPolicy(filePath, { jsonOnly: true });
+    const config = await loadPolicyConfig(filePath, { jsonOnly: true });
     expect(config.name).toBe("ok");
   });
 


### PR DESCRIPTION
## Summary

- [x] What changed
- [x] Why it changed

### What changed

Add support for loading native `PolicyPlugin` exports directly from `.js`/`.mjs` module files. The plugin loader (`loadPluginChain`) now detects modules that export a `PolicyPlugin` object (identified by a `meta` property) and adds them directly to the plugin chain with `trusted-code` trust, instead of requiring compilation through `PolicyConfig`.

**Files changed:**

| File | Change |
|------|--------|
| `packages/core/.../policy/types.ts` | Add `isNativePlugin()` type guard and `validateNativePlugin()` |
| `packages/core/.../policy/index.ts` | Export new functions |
| `packages/core/.../policy.ts` | Update `loadPolicy()` return type to `PolicyConfig \| PolicyPlugin`, detect native exports, fix Windows `import()` with `pathToFileURL` |
| `packages/core/.../policy/loader.ts` | Handle native plugins in `loadPluginChain()` — add directly to chain |
| `packages/core/.../readiness/index.ts` | Guard legacy `resolveChain` path against native plugin exports |
| `src/.../__tests__/policy-engine-types.test.ts` | 14 tests for `isNativePlugin` and `validateNativePlugin` |
| `src/.../__tests__/policy-loader.test.ts` | 6 tests for native plugin loading and engine execution |
| `src/.../__tests__/policy.test.ts` | Fix type narrowing for `loadPolicy()` union return type |

### Why it changed

The plugin engine already supports a rich 5-stage pipeline (`detect → afterDetect → beforeRecommend → recommend → afterRecommend`) with immutable patch types (`SignalPatch`, `RecommendationPatch`). However, `loadPluginChain()` only accepted `PolicyConfig` objects and compiled them — module authors could not export a raw `PolicyPlugin` to use the full hook API.

This limited what policy modules can do:
- **No signal mutation** — can't modify signals from other detectors (e.g., change status, add metadata)
- **No cross-signal recommendations** — can't compose recommendations based on signals from multiple detectors
- **No recommendation patching** — can't modify or remove recommendations from other plugins

Corporate/enterprise policies (e.g., tool governance, MCP server allow/deny lists) need these capabilities.

### Example usage

```js
// Before: PolicyConfig (criteria DSL) — limited to add/disable/override
export default {
  name: 'my-policy',
  criteria: { add: [...], disable: [...] }
};

// After: Native PolicyPlugin — full lifecycle hooks
export default {
  meta: { name: 'my-policy', sourceType: 'module', trust: 'trusted-code' },
  afterDetect: async (signals, ctx) => ({
    modify: signals
      .filter(s => s.metadata?.type === 'cursorrules')
      .map(s => ({ id: s.id, changes: { status: 'error', metadata: { blocked: true } } }))
  }),
  afterRecommend: async (recs, signals, ctx) => ({
    add: [{
      id: 'custom-rec', signalId: '...', impact: 'critical',
      message: '...', origin: { addedBy: 'my-policy' }
    }]
  })
};
```

## Checklist

- [x] Tests added or updated (20 new tests, 657 total passing)
- [x] Lint/typecheck pass
- [ ] Docs updated if needed (no user-facing docs changes needed — this extends an internal API)
