### PR TITLE
fix(core): use Copilot SDK 0.3.0+ permission response vocabulary

### DIFF
--- a/packages/core/src/services/copilot.ts
+++ b/packages/core/src/services/copilot.ts
@@ -14,6 +14,22 @@ export function logCopilotDebug(message: string): void {
   process.stderr.write(`[agentrc:copilot] ${message}\n`);
 }
 
+/**
+ * Parse a positive-integer environment variable.  Returns the parsed value
+ * when the env var is set to a finite number > 0; otherwise returns
+ * `undefined` so callers can apply their own default.  Emits a debug log
+ * when the variable is set but unparseable, so users running with
+ * `AGENTRC_DEBUG_COPILOT=1` can see when their override was rejected.
+ */
+export function parsePositiveIntEnv(name: string): number | undefined {
+  const raw = process.env[name];
+  if (raw === undefined || raw === "") return undefined;
+  const parsed = Number(raw);
+  if (Number.isFinite(parsed) && parsed > 0) return parsed;
+  logCopilotDebug(`ignoring invalid ${name}=${raw}`);
+  return undefined;
+}
+
 export type CopilotCliConfig = {
   cliPath: string;
   cliArgs?: string[];
@@ -28,6 +44,19 @@ let cachedCliConfig: CopilotCliConfig | null = null;
 let cachedCliConfigTimestamp = 0;
 const CLI_CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
 
+/**
+ * Timeout for the `--headless --version` readiness probe.  npx may need to
+ * download `@github/copilot` on first run, so it gets a longer budget; the
+ * `.bat`-shim / Node cold start on Windows still routinely exceeds 5 s, so
+ * the non-npx path uses 20 s.  Overridable via `AGENTRC_COPILOT_PROBE_TIMEOUT_MS`.
+ */
+function getHeadlessProbeTimeoutMs(config: CopilotCliConfig): number {
+  const override = parsePositiveIntEnv("AGENTRC_COPILOT_PROBE_TIMEOUT_MS");
+  if (override !== undefined) return override;
+  const isNpx = config.cliArgs?.includes("@github/copilot") ?? false;
+  return isNpx ? 30000 : 20000;
+}
+
 function cacheConfig(config: CopilotCliConfig): CopilotCliConfig {
   cachedCliConfig = config;
   cachedCliConfigTimestamp = Date.now();
@@ -40,8 +69,7 @@ export async function assertCopilotCliReady(): Promise<CopilotCliConfig> {
   logCopilotDebug(`validating CLI compatibility with ${desc}`);
 
   try {
-    const isNpx = config.cliArgs?.includes("@github/copilot") ?? false;
-    const timeout = isNpx ? 30000 : 20000;
+    const timeout = getHeadlessProbeTimeoutMs(config);
     const [cmd, args] = buildExecArgs(config, ["--headless", "--version"]);
     await execFileAsync(cmd, args, { timeout });
   } catch {
@@ -285,9 +313,7 @@ async function findFirstCompatibleCandidate(
 }
 
 async function isHeadlessCompatible(config: CopilotCliConfig): Promise<boolean> {
-  // npx may need to download the package on first run, so allow a longer timeout
-  const isNpx = config.cliArgs?.includes("@github/copilot") ?? false;
-  const timeout = isNpx ? 30000 : 20000;
+  const timeout = getHeadlessProbeTimeoutMs(config);
   try {
     const [cmd, args] = buildExecArgs(config, ["--headless", "--version"]);
     await execFileAsync(cmd, args, { timeout });

--- a/packages/core/src/services/copilot.ts
+++ b/packages/core/src/services/copilot.ts
@@ -18,10 +18,14 @@ export function logCopilotDebug(message: string): void {
  * Parse a positive-integer environment variable.  Accepts only a base-10
  * integer literal (after trimming surrounding whitespace) so surprising
  * inputs such as `"1.5"`, `"1e3"`, or `"0x10"` are rejected rather than
- * silently coerced.  Returns the parsed value when it is an integer > 0;
+ * silently coerced.  Returns the parsed value when it is a safe integer > 0;
  * otherwise returns `undefined` so callers can apply their own default.
- * Emits a debug log when the variable is set but rejected, so users running
- * with `AGENTRC_DEBUG_COPILOT=1` can see when their override was ignored.
+ *
+ * An unset, empty, or whitespace-only value is treated as "not configured"
+ * and returns `undefined` silently.  A value that is present and non-blank
+ * but not a valid positive integer is rejected and logged via
+ * `logCopilotDebug`, so users running with `AGENTRC_DEBUG_COPILOT=1` can see
+ * when their override was ignored.
  */
 export function parsePositiveIntEnv(name: string): number | undefined {
   const raw = process.env[name];
@@ -55,8 +59,10 @@ const CLI_CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
  * download `@github/copilot` on first run, so it gets a longer budget; the
  * `.bat`-shim / Node cold start on Windows still routinely exceeds 5 s, so
  * the non-npx path uses 20 s.  Overridable via `AGENTRC_COPILOT_PROBE_TIMEOUT_MS`.
+ *
+ * Exported for unit testing of the selection logic.
  */
-function getHeadlessProbeTimeoutMs(config: CopilotCliConfig): number {
+export function getHeadlessProbeTimeoutMs(config: CopilotCliConfig): number {
   const override = parsePositiveIntEnv("AGENTRC_COPILOT_PROBE_TIMEOUT_MS");
   if (override !== undefined) return override;
   const isNpx = config.cliArgs?.includes("@github/copilot") ?? false;

--- a/packages/core/src/services/copilot.ts
+++ b/packages/core/src/services/copilot.ts
@@ -60,7 +60,8 @@ const CLI_CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
  * `.bat`-shim / Node cold start on Windows still routinely exceeds 5 s, so
  * the non-npx path uses 20 s.  Overridable via `AGENTRC_COPILOT_PROBE_TIMEOUT_MS`.
  *
- * Exported for unit testing of the selection logic.
+ * @internal Exported only for unit testing of the selection logic; not part of
+ * the public API and intentionally excluded from the `@agentrc/core` barrel.
  */
 export function getHeadlessProbeTimeoutMs(config: CopilotCliConfig): number {
   const override = parsePositiveIntEnv("AGENTRC_COPILOT_PROBE_TIMEOUT_MS");

--- a/packages/core/src/services/copilot.ts
+++ b/packages/core/src/services/copilot.ts
@@ -36,7 +36,7 @@ export function parsePositiveIntEnv(name: string): number | undefined {
     const parsed = Number(trimmed);
     if (Number.isSafeInteger(parsed) && parsed > 0) return parsed;
   }
-  logCopilotDebug(`ignoring invalid ${name}=${raw}`);
+  logCopilotDebug(`ignoring invalid ${name}=${JSON.stringify(raw)}`);
   return undefined;
 }
 
@@ -65,7 +65,10 @@ const CLI_CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
 export function getHeadlessProbeTimeoutMs(config: CopilotCliConfig): number {
   const override = parsePositiveIntEnv("AGENTRC_COPILOT_PROBE_TIMEOUT_MS");
   if (override !== undefined) return override;
-  const isNpx = config.cliArgs?.includes("@github/copilot") ?? false;
+  const isNpx =
+    config.cliArgs?.some(
+      (arg) => arg === "@github/copilot" || arg.startsWith("@github/copilot@")
+    ) ?? false;
   return isNpx ? 30000 : 20000;
 }
 

--- a/packages/core/src/services/copilot.ts
+++ b/packages/core/src/services/copilot.ts
@@ -41,7 +41,7 @@ export async function assertCopilotCliReady(): Promise<CopilotCliConfig> {
 
   try {
     const isNpx = config.cliArgs?.includes("@github/copilot") ?? false;
-    const timeout = isNpx ? 30000 : 5000;
+    const timeout = isNpx ? 30000 : 20000;
     const [cmd, args] = buildExecArgs(config, ["--headless", "--version"]);
     await execFileAsync(cmd, args, { timeout });
   } catch {
@@ -287,7 +287,7 @@ async function findFirstCompatibleCandidate(
 async function isHeadlessCompatible(config: CopilotCliConfig): Promise<boolean> {
   // npx may need to download the package on first run, so allow a longer timeout
   const isNpx = config.cliArgs?.includes("@github/copilot") ?? false;
-  const timeout = isNpx ? 30000 : 5000;
+  const timeout = isNpx ? 30000 : 20000;
   try {
     const [cmd, args] = buildExecArgs(config, ["--headless", "--version"]);
     await execFileAsync(cmd, args, { timeout });

--- a/packages/core/src/services/copilot.ts
+++ b/packages/core/src/services/copilot.ts
@@ -15,17 +15,23 @@ export function logCopilotDebug(message: string): void {
 }
 
 /**
- * Parse a positive-integer environment variable.  Returns the parsed value
- * when the env var is set to a finite number > 0; otherwise returns
- * `undefined` so callers can apply their own default.  Emits a debug log
- * when the variable is set but unparseable, so users running with
- * `AGENTRC_DEBUG_COPILOT=1` can see when their override was rejected.
+ * Parse a positive-integer environment variable.  Accepts only a base-10
+ * integer literal (after trimming surrounding whitespace) so surprising
+ * inputs such as `"1.5"`, `"1e3"`, or `"0x10"` are rejected rather than
+ * silently coerced.  Returns the parsed value when it is an integer > 0;
+ * otherwise returns `undefined` so callers can apply their own default.
+ * Emits a debug log when the variable is set but rejected, so users running
+ * with `AGENTRC_DEBUG_COPILOT=1` can see when their override was ignored.
  */
 export function parsePositiveIntEnv(name: string): number | undefined {
   const raw = process.env[name];
-  if (raw === undefined || raw === "") return undefined;
-  const parsed = Number(raw);
-  if (Number.isFinite(parsed) && parsed > 0) return parsed;
+  if (raw === undefined) return undefined;
+  const trimmed = raw.trim();
+  if (trimmed === "") return undefined;
+  if (/^\d+$/u.test(trimmed)) {
+    const parsed = Number(trimmed);
+    if (Number.isSafeInteger(parsed) && parsed > 0) return parsed;
+  }
   logCopilotDebug(`ignoring invalid ${name}=${raw}`);
   return undefined;
 }

--- a/packages/core/src/services/copilotSdk.ts
+++ b/packages/core/src/services/copilotSdk.ts
@@ -6,6 +6,36 @@ import { buildExecArgs, logCopilotDebug, type CopilotCliConfig } from "./copilot
 
 export type CopilotSdkModule = typeof CopilotSdk;
 
+/**
+ * Permission response kinds the bundled Copilot CLI 1.0.x accepts.
+ * Mirrors the SDK 0.3.0 vocabulary (https://github.com/github/copilot-sdk/releases/tag/v0.3.0).
+ *
+ * Note: this is the *response* kind sent back from a permission handler,
+ * not the *request* kind (`"read"`, `"shell"`, ...) the SDK passes in.
+ */
+export type WirePermissionResponseKind =
+  | "approve-once"
+  | "approve-for-session"
+  | "approve-for-location"
+  | "reject"
+  | "user-not-available";
+
+/**
+ * Build the wire-shape permission response the Copilot CLI expects.
+ *
+ * The bundled CLI 1.0.x speaks the SDK 0.3.0+ vocabulary, but agentrc pins
+ * `@github/copilot-sdk` to ^0.2.0 whose type declarations still describe the
+ * older `"approved"` / `"denied-..."` kinds.  This helper isolates the
+ * necessary unchecked cast in one place so the rest of the codebase can stay
+ * strict; remove it and use `{ kind } as const` once the SDK dependency is
+ * bumped.
+ */
+export function wirePermissionResponse(
+  kind: WirePermissionResponseKind
+): ReturnType<CopilotSdk.PermissionHandler> {
+  return { kind } as unknown as ReturnType<CopilotSdk.PermissionHandler>;
+}
+
 let cachedSdkModule: Promise<CopilotSdkModule> | null = null;
 
 function normalizeSdkLoadError(error: unknown): Error {
@@ -156,9 +186,7 @@ export type PatchedCopilotClient = Omit<
 export function attachDefaultPermissionHandler(
   client: InstanceType<CopilotSdkModule["CopilotClient"]>
 ): void {
-  // SDK 0.3.0+ / CLI 1.0.x renamed "approved" -> "approve-once".  The 0.2.x
-  // type declarations still say "approved", so we cast through unknown.
-  const approveAll = (() => ({ kind: "approve-once" })) as unknown as CopilotSdk.PermissionHandler;
+  const approveAll: CopilotSdk.PermissionHandler = () => wirePermissionResponse("approve-once");
   const originalCreateSession = client.createSession.bind(client);
   // Override createSession so onPermissionRequest is optional at call sites.
   // The cast targets our PatchedCopilotClient createSession signature which

--- a/packages/core/src/services/copilotSdk.ts
+++ b/packages/core/src/services/copilotSdk.ts
@@ -156,7 +156,9 @@ export type PatchedCopilotClient = Omit<
 export function attachDefaultPermissionHandler(
   client: InstanceType<CopilotSdkModule["CopilotClient"]>
 ): void {
-  const approveAll: CopilotSdk.PermissionHandler = () => ({ kind: "approved" as const });
+  // SDK 0.3.0+ / CLI 1.0.x renamed "approved" -> "approve-once".  The 0.2.x
+  // type declarations still say "approved", so we cast through unknown.
+  const approveAll = (() => ({ kind: "approve-once" })) as unknown as CopilotSdk.PermissionHandler;
   const originalCreateSession = client.createSession.bind(client);
   // Override createSession so onPermissionRequest is optional at call sites.
   // The cast targets our PatchedCopilotClient createSession signature which

--- a/packages/core/src/services/instructions.ts
+++ b/packages/core/src/services/instructions.ts
@@ -226,12 +226,15 @@ const INSTRUCTION_GENERATION_EXCLUDED_TOOLS = [
 
 const READ_ONLY_PERMISSION_HANDLER: PermissionHandler = (request) => {
   if (request.kind === "read" || request.kind === "custom-tool") {
-    return { kind: "approved" };
+    // SDK 0.3.0+ / CLI 1.0.x renamed "approved" -> "approve-once".
+    // Cast through unknown so the 0.2.x typings (which still declare "approved")
+    // continue to compile while we emit the wire shape the new CLI requires.
+    return { kind: "approve-once" } as unknown as ReturnType<PermissionHandler>;
   }
 
   return {
-    kind: "denied-no-approval-rule-and-could-not-request-from-user"
-  };
+    kind: "user-not-available"
+  } as unknown as ReturnType<PermissionHandler>;
 };
 
 function getSessionError(errorMsg: string): Error {

--- a/packages/core/src/services/instructions.ts
+++ b/packages/core/src/services/instructions.ts
@@ -8,8 +8,8 @@ import { ensureDir, safeWriteFile } from "../utils/fs";
 
 import type { Area, InstructionStrategy } from "./analyzer";
 import { sanitizeAreaName } from "./analyzer";
-import { assertCopilotCliReady } from "./copilot";
-import { createCopilotClient, loadCopilotSdk } from "./copilotSdk";
+import { assertCopilotCliReady, parsePositiveIntEnv } from "./copilot";
+import { createCopilotClient, loadCopilotSdk, wirePermissionResponse } from "./copilotSdk";
 import type { FileAction } from "./generator";
 import { getSkillDirectory } from "./skills";
 
@@ -224,17 +224,27 @@ const INSTRUCTION_GENERATION_EXCLUDED_TOOLS = [
   "str_replace_editor"
 ];
 
+/**
+ * Upper bound for a single `session.sendAndWait` call during instruction
+ * generation.  Generation drives an agent loop with many tool calls and on
+ * slower endpoints or larger repos the total run can exceed the SDK's default
+ * 3-minute budget.  This is a ceiling, not an idle wait — fast runs complete
+ * well under a minute.  Overridable via `AGENTRC_INSTRUCTION_TIMEOUT_MS` for
+ * environments with slow networks or very large repositories.
+ *
+ * Implemented as a function (rather than a module-load constant) so test code
+ * can stub the env var via `vi.stubEnv` after the module has been imported.
+ */
+function getInstructionGenerationTimeoutMs(): number {
+  return parsePositiveIntEnv("AGENTRC_INSTRUCTION_TIMEOUT_MS") ?? 600_000;
+}
+
 const READ_ONLY_PERMISSION_HANDLER: PermissionHandler = (request) => {
   if (request.kind === "read" || request.kind === "custom-tool") {
-    // SDK 0.3.0+ / CLI 1.0.x renamed "approved" -> "approve-once".
-    // Cast through unknown so the 0.2.x typings (which still declare "approved")
-    // continue to compile while we emit the wire shape the new CLI requires.
-    return { kind: "approve-once" } as unknown as ReturnType<PermissionHandler>;
+    return wirePermissionResponse("approve-once");
   }
 
-  return {
-    kind: "user-not-available"
-  } as unknown as ReturnType<PermissionHandler>;
+  return wirePermissionResponse("user-not-available");
 };
 
 function getSessionError(errorMsg: string): Error {
@@ -371,7 +381,7 @@ ${existingSection}`;
     progress("Analyzing codebase...");
     let sendError: unknown;
     try {
-      await session.sendAndWait({ prompt }, 600000);
+      await session.sendAndWait({ prompt }, getInstructionGenerationTimeoutMs());
     } catch (err) {
       sendError = err;
     } finally {
@@ -474,7 +484,7 @@ ${existingSection ? `\nDo NOT duplicate content already covered by existing inst
     progress(`Analyzing area "${area.name}"...`);
     let sendError: unknown;
     try {
-      await session.sendAndWait({ prompt }, 600000);
+      await session.sendAndWait({ prompt }, getInstructionGenerationTimeoutMs());
     } catch (err) {
       sendError = err;
     } finally {
@@ -775,7 +785,7 @@ ${existingSection ? `\nDo NOT duplicate content from existing instruction files\
 
   let sendError: unknown;
   try {
-    await session.sendAndWait({ prompt }, 600000);
+    await session.sendAndWait({ prompt }, getInstructionGenerationTimeoutMs());
   } catch (err) {
     sendError = err;
   } finally {
@@ -859,7 +869,7 @@ Description: ${options.topic.description}`;
 
   let sendError: unknown;
   try {
-    await session.sendAndWait({ prompt }, 600000);
+    await session.sendAndWait({ prompt }, getInstructionGenerationTimeoutMs());
   } catch (err) {
     sendError = err;
   } finally {

--- a/packages/core/src/services/instructions.ts
+++ b/packages/core/src/services/instructions.ts
@@ -351,6 +351,8 @@ export async function generateCopilotInstructions(
       skillDirectories: [rootSkillDir]
     });
 
+    const timeoutMs = getInstructionGenerationTimeoutMs();
+
     await trySetAutopilot(session);
 
     let content = "";
@@ -381,7 +383,7 @@ ${existingSection}`;
     progress("Analyzing codebase...");
     let sendError: unknown;
     try {
-      await session.sendAndWait({ prompt }, getInstructionGenerationTimeoutMs());
+      await session.sendAndWait({ prompt }, timeoutMs);
     } catch (err) {
       sendError = err;
     } finally {
@@ -452,6 +454,8 @@ export async function generateAreaInstructions(
       skillDirectories: [areaSkillDir]
     });
 
+    const timeoutMs = getInstructionGenerationTimeoutMs();
+
     await trySetAutopilot(session);
 
     let content = "";
@@ -484,7 +488,7 @@ ${existingSection ? `\nDo NOT duplicate content already covered by existing inst
     progress(`Analyzing area "${area.name}"...`);
     let sendError: unknown;
     try {
-      await session.sendAndWait({ prompt }, getInstructionGenerationTimeoutMs());
+      await session.sendAndWait({ prompt }, timeoutMs);
     } catch (err) {
       sendError = err;
     } finally {
@@ -712,6 +716,7 @@ async function generateNestedHub(
     area?: Area;
     childAreas?: Area[];
     model?: string;
+    timeoutMs: number;
     onProgress?: (message: string) => void;
   }
 ): Promise<HubResult> {
@@ -785,7 +790,7 @@ ${existingSection ? `\nDo NOT duplicate content from existing instruction files\
 
   let sendError: unknown;
   try {
-    await session.sendAndWait({ prompt }, getInstructionGenerationTimeoutMs());
+    await session.sendAndWait({ prompt }, options.timeoutMs);
   } catch (err) {
     sendError = err;
   } finally {
@@ -812,6 +817,7 @@ async function generateNestedDetail(
     topic: NestedTopic;
     area?: Area;
     model?: string;
+    timeoutMs: number;
     onProgress?: (message: string) => void;
   }
 ): Promise<string> {
@@ -869,7 +875,7 @@ Description: ${options.topic.description}`;
 
   let sendError: unknown;
   try {
-    await session.sendAndWait({ prompt }, getInstructionGenerationTimeoutMs());
+    await session.sendAndWait({ prompt }, options.timeoutMs);
   } catch (err) {
     sendError = err;
   } finally {
@@ -908,6 +914,8 @@ export async function generateNestedInstructions(
   progress("Starting Copilot SDK...");
   const client = await createCopilotClient(cliConfig);
 
+  const timeoutMs = getInstructionGenerationTimeoutMs();
+
   try {
     // Step 1: Generate hub
     const { hubContent, topics } = await generateNestedHub(client, {
@@ -916,6 +924,7 @@ export async function generateNestedInstructions(
       area: options.area,
       childAreas: options.childAreas,
       model: options.model,
+      timeoutMs,
       onProgress: options.onProgress
     });
 
@@ -944,6 +953,7 @@ export async function generateNestedInstructions(
           topic,
           area: options.area,
           model: options.model,
+          timeoutMs,
           onProgress: options.onProgress
         });
         if (detailContent) {

--- a/packages/core/src/services/instructions.ts
+++ b/packages/core/src/services/instructions.ts
@@ -371,7 +371,7 @@ ${existingSection}`;
     progress("Analyzing codebase...");
     let sendError: unknown;
     try {
-      await session.sendAndWait({ prompt }, 180000);
+      await session.sendAndWait({ prompt }, 600000);
     } catch (err) {
       sendError = err;
     } finally {
@@ -474,7 +474,7 @@ ${existingSection ? `\nDo NOT duplicate content already covered by existing inst
     progress(`Analyzing area "${area.name}"...`);
     let sendError: unknown;
     try {
-      await session.sendAndWait({ prompt }, 180000);
+      await session.sendAndWait({ prompt }, 600000);
     } catch (err) {
       sendError = err;
     } finally {
@@ -775,7 +775,7 @@ ${existingSection ? `\nDo NOT duplicate content from existing instruction files\
 
   let sendError: unknown;
   try {
-    await session.sendAndWait({ prompt }, 180000);
+    await session.sendAndWait({ prompt }, 600000);
   } catch (err) {
     sendError = err;
   } finally {
@@ -859,7 +859,7 @@ Description: ${options.topic.description}`;
 
   let sendError: unknown;
   try {
-    await session.sendAndWait({ prompt }, 180000);
+    await session.sendAndWait({ prompt }, 600000);
   } catch (err) {
     sendError = err;
   } finally {

--- a/src/services/__tests__/copilot.test.ts
+++ b/src/services/__tests__/copilot.test.ts
@@ -3,7 +3,7 @@ import {
   getHeadlessProbeTimeoutMs,
   parsePositiveIntEnv
 } from "@agentrc/core/services/copilot";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 describe("extractModelChoices", () => {
   it("extracts model names from a single-line --help output", () => {
@@ -42,18 +42,13 @@ describe("extractModelChoices", () => {
 
 describe("parsePositiveIntEnv", () => {
   const NAME = "AGENTRC_TEST_TIMEOUT_MS";
-  const original = process.env[NAME];
 
   beforeEach(() => {
-    delete process.env[NAME];
+    vi.stubEnv(NAME, undefined);
   });
 
   afterEach(() => {
-    if (original === undefined) {
-      delete process.env[NAME];
-    } else {
-      process.env[NAME] = original;
-    }
+    vi.unstubAllEnvs();
   });
 
   it("returns undefined when the variable is unset", () => {
@@ -61,84 +56,88 @@ describe("parsePositiveIntEnv", () => {
   });
 
   it("parses a plain positive integer", () => {
-    process.env[NAME] = "5000";
+    vi.stubEnv(NAME, "5000");
     expect(parsePositiveIntEnv(NAME)).toBe(5000);
   });
 
   it("trims surrounding whitespace", () => {
-    process.env[NAME] = "  42  ";
+    vi.stubEnv(NAME, "  42  ");
     expect(parsePositiveIntEnv(NAME)).toBe(42);
   });
 
   it("accepts leading zeros as base-10 (no octal)", () => {
-    process.env[NAME] = "007";
+    vi.stubEnv(NAME, "007");
     expect(parsePositiveIntEnv(NAME)).toBe(7);
   });
 
   it("rejects non-integer decimals like 1.5", () => {
-    process.env[NAME] = "1.5";
+    vi.stubEnv(NAME, "1.5");
     expect(parsePositiveIntEnv(NAME)).toBeUndefined();
   });
 
   it("rejects scientific notation like 1e3", () => {
-    process.env[NAME] = "1e3";
+    vi.stubEnv(NAME, "1e3");
     expect(parsePositiveIntEnv(NAME)).toBeUndefined();
   });
 
   it("rejects hex literals like 0x10", () => {
-    process.env[NAME] = "0x10";
+    vi.stubEnv(NAME, "0x10");
     expect(parsePositiveIntEnv(NAME)).toBeUndefined();
   });
 
   it("rejects signed values", () => {
-    process.env[NAME] = "+5";
+    vi.stubEnv(NAME, "+5");
     expect(parsePositiveIntEnv(NAME)).toBeUndefined();
   });
 
   it("rejects zero and negatives", () => {
-    process.env[NAME] = "0";
+    vi.stubEnv(NAME, "0");
     expect(parsePositiveIntEnv(NAME)).toBeUndefined();
-    process.env[NAME] = "-5";
+    vi.stubEnv(NAME, "-5");
     expect(parsePositiveIntEnv(NAME)).toBeUndefined();
   });
 
   it("rejects empty and whitespace-only values", () => {
-    process.env[NAME] = "";
+    vi.stubEnv(NAME, "");
     expect(parsePositiveIntEnv(NAME)).toBeUndefined();
-    process.env[NAME] = "   ";
+    vi.stubEnv(NAME, "   ");
     expect(parsePositiveIntEnv(NAME)).toBeUndefined();
   });
 
   it("rejects non-numeric junk", () => {
-    process.env[NAME] = "5px";
+    vi.stubEnv(NAME, "5px");
     expect(parsePositiveIntEnv(NAME)).toBeUndefined();
   });
 
   it("rejects values beyond the safe-integer range", () => {
-    process.env[NAME] = "99999999999999999999";
+    vi.stubEnv(NAME, "99999999999999999999");
     expect(parsePositiveIntEnv(NAME)).toBeUndefined();
   });
 });
 
 describe("getHeadlessProbeTimeoutMs", () => {
   const ENV = "AGENTRC_COPILOT_PROBE_TIMEOUT_MS";
-  const original = process.env[ENV];
 
   beforeEach(() => {
-    delete process.env[ENV];
+    vi.stubEnv(ENV, undefined);
   });
 
   afterEach(() => {
-    if (original === undefined) {
-      delete process.env[ENV];
-    } else {
-      process.env[ENV] = original;
-    }
+    vi.unstubAllEnvs();
   });
 
   it("uses 30s for the npx candidate", () => {
     expect(
       getHeadlessProbeTimeoutMs({ cliPath: "npx", cliArgs: ["--yes", "@github/copilot"] })
+    ).toBe(30000);
+  });
+
+  it("uses 30s for a versioned npx spec (e.g. @github/copilot@latest)", () => {
+    expect(
+      getHeadlessProbeTimeoutMs({ cliPath: "npx", cliArgs: ["--yes", "@github/copilot@latest"] })
+    ).toBe(30000);
+    expect(
+      getHeadlessProbeTimeoutMs({ cliPath: "npx", cliArgs: ["-y", "@github/copilot@0.3.0"] })
     ).toBe(30000);
   });
 
@@ -152,8 +151,14 @@ describe("getHeadlessProbeTimeoutMs", () => {
     ).toBe(20000);
   });
 
+  it("does not treat a substring match (e.g. @github/copilot-foo) as npx", () => {
+    expect(
+      getHeadlessProbeTimeoutMs({ cliPath: "npx", cliArgs: ["--yes", "@github/copilot-foo"] })
+    ).toBe(20000);
+  });
+
   it("honors a valid override for both npx and non-npx candidates", () => {
-    process.env[ENV] = "12345";
+    vi.stubEnv(ENV, "12345");
     expect(getHeadlessProbeTimeoutMs({ cliPath: "/usr/bin/copilot" })).toBe(12345);
     expect(
       getHeadlessProbeTimeoutMs({ cliPath: "npx", cliArgs: ["--yes", "@github/copilot"] })
@@ -161,7 +166,7 @@ describe("getHeadlessProbeTimeoutMs", () => {
   });
 
   it("ignores an invalid override and falls back to the default", () => {
-    process.env[ENV] = "not-a-number";
+    vi.stubEnv(ENV, "not-a-number");
     expect(getHeadlessProbeTimeoutMs({ cliPath: "/usr/bin/copilot" })).toBe(20000);
   });
 });

--- a/src/services/__tests__/copilot.test.ts
+++ b/src/services/__tests__/copilot.test.ts
@@ -1,5 +1,5 @@
-import { extractModelChoices } from "@agentrc/core/services/copilot";
-import { describe, expect, it } from "vitest";
+import { extractModelChoices, parsePositiveIntEnv } from "@agentrc/core/services/copilot";
+import { afterEach, describe, expect, it } from "vitest";
 
 describe("extractModelChoices", () => {
   it("extracts model names from a single-line --help output", () => {
@@ -33,5 +33,77 @@ describe("extractModelChoices", () => {
   it("handles help text written to stderr (same format)", () => {
     const stderr = '  --model <model>  Model (choices: "gpt-5", "gpt-4.1", "claude-sonnet-4.5")';
     expect(extractModelChoices(stderr)).toEqual(["gpt-5", "gpt-4.1", "claude-sonnet-4.5"]);
+  });
+});
+
+describe("parsePositiveIntEnv", () => {
+  const NAME = "AGENTRC_TEST_TIMEOUT_MS";
+
+  afterEach(() => {
+    delete process.env[NAME];
+  });
+
+  it("returns undefined when the variable is unset", () => {
+    delete process.env[NAME];
+    expect(parsePositiveIntEnv(NAME)).toBeUndefined();
+  });
+
+  it("parses a plain positive integer", () => {
+    process.env[NAME] = "5000";
+    expect(parsePositiveIntEnv(NAME)).toBe(5000);
+  });
+
+  it("trims surrounding whitespace", () => {
+    process.env[NAME] = "  42  ";
+    expect(parsePositiveIntEnv(NAME)).toBe(42);
+  });
+
+  it("accepts leading zeros as base-10 (no octal)", () => {
+    process.env[NAME] = "007";
+    expect(parsePositiveIntEnv(NAME)).toBe(7);
+  });
+
+  it("rejects non-integer decimals like 1.5", () => {
+    process.env[NAME] = "1.5";
+    expect(parsePositiveIntEnv(NAME)).toBeUndefined();
+  });
+
+  it("rejects scientific notation like 1e3", () => {
+    process.env[NAME] = "1e3";
+    expect(parsePositiveIntEnv(NAME)).toBeUndefined();
+  });
+
+  it("rejects hex literals like 0x10", () => {
+    process.env[NAME] = "0x10";
+    expect(parsePositiveIntEnv(NAME)).toBeUndefined();
+  });
+
+  it("rejects signed values", () => {
+    process.env[NAME] = "+5";
+    expect(parsePositiveIntEnv(NAME)).toBeUndefined();
+  });
+
+  it("rejects zero and negatives", () => {
+    process.env[NAME] = "0";
+    expect(parsePositiveIntEnv(NAME)).toBeUndefined();
+    process.env[NAME] = "-5";
+    expect(parsePositiveIntEnv(NAME)).toBeUndefined();
+  });
+
+  it("rejects empty and whitespace-only values", () => {
+    process.env[NAME] = "";
+    expect(parsePositiveIntEnv(NAME)).toBeUndefined();
+    process.env[NAME] = "   ";
+    expect(parsePositiveIntEnv(NAME)).toBeUndefined();
+  });
+
+  it("rejects non-numeric junk", () => {
+    process.env[NAME] = "5px";
+    expect(parsePositiveIntEnv(NAME)).toBeUndefined();
+  });
+
+  it("rejects values beyond the safe-integer range", () => {
+    process.env[NAME] = "99999999999999999999";
+    expect(parsePositiveIntEnv(NAME)).toBeUndefined();
   });
 });

--- a/src/services/__tests__/copilot.test.ts
+++ b/src/services/__tests__/copilot.test.ts
@@ -1,5 +1,9 @@
-import { extractModelChoices, parsePositiveIntEnv } from "@agentrc/core/services/copilot";
-import { afterEach, describe, expect, it } from "vitest";
+import {
+  extractModelChoices,
+  getHeadlessProbeTimeoutMs,
+  parsePositiveIntEnv
+} from "@agentrc/core/services/copilot";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 describe("extractModelChoices", () => {
   it("extracts model names from a single-line --help output", () => {
@@ -38,13 +42,21 @@ describe("extractModelChoices", () => {
 
 describe("parsePositiveIntEnv", () => {
   const NAME = "AGENTRC_TEST_TIMEOUT_MS";
+  const original = process.env[NAME];
 
-  afterEach(() => {
+  beforeEach(() => {
     delete process.env[NAME];
   });
 
+  afterEach(() => {
+    if (original === undefined) {
+      delete process.env[NAME];
+    } else {
+      process.env[NAME] = original;
+    }
+  });
+
   it("returns undefined when the variable is unset", () => {
-    delete process.env[NAME];
     expect(parsePositiveIntEnv(NAME)).toBeUndefined();
   });
 
@@ -105,5 +117,51 @@ describe("parsePositiveIntEnv", () => {
   it("rejects values beyond the safe-integer range", () => {
     process.env[NAME] = "99999999999999999999";
     expect(parsePositiveIntEnv(NAME)).toBeUndefined();
+  });
+});
+
+describe("getHeadlessProbeTimeoutMs", () => {
+  const ENV = "AGENTRC_COPILOT_PROBE_TIMEOUT_MS";
+  const original = process.env[ENV];
+
+  beforeEach(() => {
+    delete process.env[ENV];
+  });
+
+  afterEach(() => {
+    if (original === undefined) {
+      delete process.env[ENV];
+    } else {
+      process.env[ENV] = original;
+    }
+  });
+
+  it("uses 30s for the npx candidate", () => {
+    expect(
+      getHeadlessProbeTimeoutMs({ cliPath: "npx", cliArgs: ["--yes", "@github/copilot"] })
+    ).toBe(30000);
+  });
+
+  it("uses 20s for a bare-path (non-npx) candidate", () => {
+    expect(getHeadlessProbeTimeoutMs({ cliPath: "/usr/bin/copilot" })).toBe(20000);
+  });
+
+  it("uses 20s when cliArgs do not include @github/copilot", () => {
+    expect(
+      getHeadlessProbeTimeoutMs({ cliPath: process.execPath, cliArgs: ["/path/to/npm-loader.js"] })
+    ).toBe(20000);
+  });
+
+  it("honors a valid override for both npx and non-npx candidates", () => {
+    process.env[ENV] = "12345";
+    expect(getHeadlessProbeTimeoutMs({ cliPath: "/usr/bin/copilot" })).toBe(12345);
+    expect(
+      getHeadlessProbeTimeoutMs({ cliPath: "npx", cliArgs: ["--yes", "@github/copilot"] })
+    ).toBe(12345);
+  });
+
+  it("ignores an invalid override and falls back to the default", () => {
+    process.env[ENV] = "not-a-number";
+    expect(getHeadlessProbeTimeoutMs({ cliPath: "/usr/bin/copilot" })).toBe(20000);
   });
 });

--- a/src/services/__tests__/copilotSdk.test.ts
+++ b/src/services/__tests__/copilotSdk.test.ts
@@ -36,13 +36,14 @@ describe("attachDefaultPermissionHandler", () => {
     expect(passedConfig.config).toHaveProperty("onPermissionRequest");
     expect(typeof passedConfig.config.onPermissionRequest).toBe("function");
 
-    // The injected handler should approve all request kinds
+    // The injected handler should approve all request kinds.
+    // SDK 0.3.0+ / CLI 1.0.x renamed "approved" -> "approve-once".
     const handler = passedConfig.config.onPermissionRequest as (req: unknown) => { kind: string };
-    expect(handler({ kind: "shell" })).toEqual({ kind: "approved" });
-    expect(handler({ kind: "write" })).toEqual({ kind: "approved" });
-    expect(handler({ kind: "read" })).toEqual({ kind: "approved" });
-    expect(handler({ kind: "url" })).toEqual({ kind: "approved" });
-    expect(handler({ kind: "mcp" })).toEqual({ kind: "approved" });
+    expect(handler({ kind: "shell" })).toEqual({ kind: "approve-once" });
+    expect(handler({ kind: "write" })).toEqual({ kind: "approve-once" });
+    expect(handler({ kind: "read" })).toEqual({ kind: "approve-once" });
+    expect(handler({ kind: "url" })).toEqual({ kind: "approve-once" });
+    expect(handler({ kind: "mcp" })).toEqual({ kind: "approve-once" });
   });
 
   it("preserves a caller-supplied onPermissionRequest", async () => {

--- a/src/services/__tests__/instructions.test.ts
+++ b/src/services/__tests__/instructions.test.ts
@@ -816,17 +816,20 @@ describe("instruction generation sessions", () => {
   const expectReadOnlyPermissions = async (
     onPermissionRequest: (request: { kind: string }) => Promise<{ kind: string }> | { kind: string }
   ) => {
+    // SDK 0.3.0+ / CLI 1.0.x renamed the permission response vocabulary:
+    //   "approved" -> "approve-once"
+    //   "denied-no-approval-rule-and-could-not-request-from-user" -> "user-not-available"
     await expect(Promise.resolve(onPermissionRequest({ kind: "read" }))).resolves.toEqual({
-      kind: "approved"
+      kind: "approve-once"
     });
     await expect(Promise.resolve(onPermissionRequest({ kind: "custom-tool" }))).resolves.toEqual({
-      kind: "approved"
+      kind: "approve-once"
     });
     await expect(Promise.resolve(onPermissionRequest({ kind: "shell" }))).resolves.toEqual({
-      kind: "denied-no-approval-rule-and-could-not-request-from-user"
+      kind: "user-not-available"
     });
     await expect(Promise.resolve(onPermissionRequest({ kind: "write" }))).resolves.toEqual({
-      kind: "denied-no-approval-rule-and-could-not-request-from-user"
+      kind: "user-not-available"
     });
   };
 


### PR DESCRIPTION
## Summary

- **What changed** — fixes three issues that together cause `agentrc instructions` to silently produce an unusable `.github/copilot-instructions.md` containing an LLM-authored error message instead of real instructions, and add intermittent reliability issues on Windows.
- **Why it changed** — the permission-response vocabulary used by `agentrc` is from Copilot SDK 0.2.x and is rejected by the bundled Copilot CLI 1.0.x. Every tool call fails with `unexpected user permission response`, the agent generalizes the failure, and writes an error message into the output file. Two adjacent timeout values were also too tight for the post-fix end-to-end flow.

This PR is what's needed to restore working instruction generation on a current Copilot CLI install.

## Root cause (the first commit — required)

Copilot SDK [renamed the permission-handler response vocabulary in v0.3.0](https://github.com/github/copilot-sdk/releases/tag/v0.3.0), and the bundled CLI 1.0.x only accepts the new names:

| Old (sent by agentrc) | New (expected by CLI) |
|---|---|
| `"approved"` | `"approve-once"` |
| `"denied-no-approval-rule-and-could-not-request-from-user"` | `"user-not-available"` |
| `"denied-interactively-by-user"` | `"reject"` |

`agentrc` is pinned to `@github/copilot-sdk: ^0.2.0` (resolves to 0.2.2) and still emits the old kinds from two places:

- `READ_ONLY_PERMISSION_HANDLER` in `packages/core/src/services/instructions.ts` (used by `generateCopilotInstructions`, `generateAreaInstructions`, and the nested variants)
- `attachDefaultPermissionHandler`'s `approveAll` in `packages/core/src/services/copilotSdk.ts`

When the CLI receives `kind: "approved"` it returns `Error: unexpected user permission response` in every tool result. The agent then reasons "all tools are failing — this must be an environment problem", emits a short error message via the custom `emit_file_content` tool, and `agentrc` writes that string verbatim to disk and exits 0.

The file then becomes self-reinforcing on subsequent runs: the Copilot CLI auto-loads `.github/copilot-instructions.md` as custom instructions, so the next attempt reads the previous run's error message as authoritative context and produces the same output. Deleting the file between retries was necessary to confirm the underlying cause.

### Evidence from the CLI debug log

With `AGENTRC_DEBUG_COPILOT=1` and `~/.copilot/logs/process-*.log`:

```
[DEBUG] Permission request (kind=read): routing via PermissionService
[DEBUG] respondToPermission: requestId=..., kind=approved             ← old vocab
...
tool_result for glob: "Failed to execute `glob` tool ... due to error:
  Error: unexpected user permission response"
...
reasoning_text: "All tools seem to be failing with 'unexpected user
  permission response'. This is an environment issue, not a code or
  policy problem. I should inform the user about this..."
...
emit_file_content({ content: "All tools are failing. Please restart..." })
```

After the fix the same logs show `kind=approve-once`, no `unexpected user permission response`, and end-to-end successful generation.

## Two adjacent reliability issues fixed in follow-up commits

These are observable only after the protocol fix above lets the agent run through to the end. They're small and independent — kept as separate commits so they can be cherry-picked or reverted on their own.

**Commit 2: `fix(core): bump headless probe timeout to 20s for Windows cold start`** — `isHeadlessCompatible` runs the candidate CLI with `--headless --version` under a 5-second timeout for non-npx invocations. On Windows the discovered binary is a `.bat` shim that spawns Node; the first probe of a session intermittently exceeds 5s even on a warm machine, and the user sees a spurious "does not support `--headless`" failure that retries moments later succeed. This matches the intermittent symptom reported in #153. Bumping the non-npx budget to 20s (npx already gets 30s) resolves it in practice without making the failure case noticeably slower.

**Commit 3: `fix(core): extend session.sendAndWait budget to 600s for instruction generation`** — Generation drives a multi-step agent loop (read manifests, glob the tree, sample files, emit markdown). On a non-trivial repo with a reasoning model this routinely runs longer than the current 180s, surfacing as `Timeout after 180000ms waiting for session.idle` with no output. 600s is an upper bound, not an idle wait — fast runs finish in under a minute.

## Repro

Before the fix:

```powershell
# Windows 11, Node 24, Copilot CLI 1.0.61
cd <any-repo>
Remove-Item .github\copilot-instructions.md -ErrorAction Ignore
npx -y github:microsoft/agentrc instructions --force
# exit 0, file contains an LLM-authored error message
```

After the fix:

```
npm install && npm run build
# (or: npm link, then run `agentrc instructions --force` from the target repo)
# exit 0, file contains a real, structured copilot-instructions.md
```

Reproducible across multiple repos, multiple models (`claude-sonnet-4.6`, `gpt-5.5`), and both stable and Insiders CLI binaries.

## Out of scope

- **Bumping `@github/copilot-sdk` to ≥ 0.3.0.** The 0.2.x type declarations still declare the old literals, so this PR casts through `unknown` to emit the new wire shape while keeping the dependency unchanged. Bumping to SDK 1.x is not a drop-in upgrade — it removes `cliUrl`, `useStdio`, and `session.destroy()` and tightens `SessionEventHandler` typings. Worth doing as a separate change.
- **Adding a smoke test that runs `agentrc instructions` against a fixture repo.** The current test suite cannot catch this regression class because it does not exercise the SDK session end-to-end. The targeted unit-level updates in this PR are the bare minimum; a real smoke test is a larger follow-up.
- **Validating the agent's `emit_file_content` output before writing.** A short, heading-free, or known-error-pattern payload should arguably warn rather than overwrite, but that's a behavioural change worth its own discussion.
- **Documenting `AGENTRC_DEBUG_COPILOT` and `AGENTRC_COPILOT_CLI_PATH`** in README/CONTRIBUTING. Both are referenced only in source today and were essential for diagnosing this issue.

## Checklist

- [x] Tests added or updated — `attachDefaultPermissionHandler` and `expectReadOnlyPermissions` updated to assert the new vocabulary
- [x] Lint/typecheck pass — `npm run lint`, `npm run typecheck`, `npm run build` all green
- [x] Docs updated if needed — no user-facing docs reference the permission vocabulary; the two timeout constants are internal

## Environment used to repro and verify

- Windows 11, PowerShell 7, Node 24.14.1
- `@github/copilot-sdk@0.2.2` (resolved from `^0.2.0`)
- GitHub Copilot CLI 1.0.61 (`%APPDATA%\Code - Insiders\...\copilotCli\copilot.bat`)
- Models: `claude-sonnet-4.6` (default) and `gpt-5.5` — both reproduce

## Related

- #153 — same end-user symptom on an earlier CLI/SDK pairing. The "intermittent on retry" framing in that report fits the cold-start probe timeout (commit 2), but the underlying permission protocol mismatch (commit 1) was the deterministic cause that #153's repro likely also encountered.
