### PR TITLE
fix(instructions): deduplicate workspace content in nested AGENTS.md generation

### DIFF
--- a/packages/core/src/services/generator.ts
+++ b/packages/core/src/services/generator.ts
@@ -20,6 +20,8 @@ export type GenerateOptions = {
   selections: string[];
   force: boolean;
   dryRun?: boolean;
+  /** Relative path of the generated instruction file referenced by VS Code settings. Defaults to `.github/copilot-instructions.md`. */
+  instructionFile?: string;
 };
 
 async function writeOrPreview(
@@ -58,7 +60,7 @@ export async function generateConfigs(options: GenerateOptions): Promise<Generat
     files.push(
       await writeOrPreview(
         path.join(repoPath, ".vscode", "settings.json"),
-        renderVscodeSettings(analysis),
+        renderVscodeSettings(analysis, options.instructionFile),
         { dryRun, force }
       )
     );
@@ -96,16 +98,17 @@ function renderMcp(): string {
   );
 }
 
-function renderVscodeSettings(analysis: RepoAnalysis): string {
+function renderVscodeSettings(
+  analysis: RepoAnalysis,
+  instructionFile = ".github/copilot-instructions.md"
+): string {
   const reviewFocus = analysis.frameworks.length
     ? `Focus on ${analysis.frameworks.join(", ")} best practices and repo conventions.`
     : "Focus on repo conventions and maintainability.";
 
   return JSON.stringify(
     {
-      "github.copilot.chat.codeGeneration.instructions": [
-        { file: ".github/copilot-instructions.md" }
-      ],
+      "github.copilot.chat.codeGeneration.instructions": [{ file: instructionFile }],
       "github.copilot.chat.reviewSelection.instructions": [{ text: reviewFocus }],
       "chat.promptFiles": true,
       "chat.mcp.enabled": true

--- a/packages/core/src/services/instructions.ts
+++ b/packages/core/src/services/instructions.ts
@@ -171,6 +171,26 @@ export function buildExistingInstructionsSection(ctx: ExistingInstructionsContex
 }
 
 /**
+ * Build a prompt section embedding the freshly-generated root instruction content
+ * so nested (per-area / per-crate) generation knows what the root file already
+ * covers and avoids restating it. Emits nothing when no root content is provided.
+ */
+export function buildRootContextSection(rootContent?: string): string {
+  const trimmed = rootContent?.trim();
+  if (!trimmed) return "";
+
+  return [
+    "",
+    "## Root instructions already cover",
+    "The root instruction file already covers the following workspace-wide content. " +
+      "Do NOT repeat or restate it in this file; cover only this area/crate's unique details:",
+    "",
+    trimmed,
+    ""
+  ].join("\n");
+}
+
+/**
  * Strip outer markdown code fences that LLMs sometimes wrap around generated file content.
  * Only removes a single outer fence (```markdown or bare ```) — internal fences are preserved.
  */
@@ -294,6 +314,8 @@ type GenerateInstructionsOptions = {
   strategy?: InstructionStrategy;
   detailDir?: string;
   claudeMd?: boolean;
+  /** Content of the already-generated root instruction file, used to avoid duplicating it in nested outputs. */
+  rootContent?: string;
 };
 
 export async function generateCopilotInstructions(
@@ -392,6 +414,8 @@ type GenerateAreaInstructionsOptions = {
   strategy?: InstructionStrategy;
   detailDir?: string;
   claudeMd?: boolean;
+  /** Content of the already-generated root instruction file, used to avoid duplicating it in area outputs. */
+  rootContent?: string;
 };
 
 export async function generateAreaInstructions(
@@ -700,6 +724,7 @@ async function generateNestedHub(
     childAreas?: Area[];
     model?: string;
     onProgress?: (message: string) => void;
+    rootContent?: string;
   }
 ): Promise<HubResult> {
   const progress = options.onProgress ?? (() => {});
@@ -763,12 +788,13 @@ async function generateNestedHub(
     : "";
 
   // Invoke the nested-hub skill with repo/area-specific context
+  const rootContextSection = buildRootContextSection(options.rootContent);
   const prompt = `/nested-hub Generate a lean AGENTS.md hub file (~90-120 lines).${areaContext}${parentContext}
 
 Detail files go in \`${options.detailDir}/\`.${childContext}
 
 Recommend 3-5 topics for deep-dive detail files. Each slug becomes: \`${options.detailDir}/{slug}.md\`.
-${existingSection ? `\nDo NOT duplicate content from existing instruction files\n${existingSection}` : ""}`;
+${rootContextSection}${existingSection ? `\nDo NOT duplicate content from existing instruction files\n${existingSection}` : ""}`;
 
   let sendError: unknown;
   try {
@@ -800,6 +826,7 @@ async function generateNestedDetail(
     area?: Area;
     model?: string;
     onProgress?: (message: string) => void;
+    rootContent?: string;
   }
 ): Promise<string> {
   const progress = options.onProgress ?? (() => {});
@@ -848,8 +875,9 @@ async function generateNestedDetail(
     : "Focus on the entire repository.";
 
   // Invoke the nested-detail skill with topic-specific context
+  const rootContextSection = buildRootContextSection(options.rootContent);
   const prompt = `/nested-detail Generate a deep-dive instruction file about "${options.topic.title}" for this codebase.
-${areaContext}
+${areaContext}${rootContextSection}
 
 Topic: ${options.topic.title}
 Description: ${options.topic.description}`;
@@ -903,7 +931,8 @@ export async function generateNestedInstructions(
       area: options.area,
       childAreas: options.childAreas,
       model: options.model,
-      onProgress: options.onProgress
+      onProgress: options.onProgress,
+      rootContent: options.rootContent
     });
 
     // Determine output paths
@@ -931,7 +960,8 @@ export async function generateNestedInstructions(
           topic,
           area: options.area,
           model: options.model,
-          onProgress: options.onProgress
+          onProgress: options.onProgress,
+          rootContent: options.rootContent
         });
         if (detailContent) {
           result.details.push({
@@ -980,6 +1010,7 @@ export async function generateNestedAreaInstructions(
     model: options.model,
     onProgress: options.onProgress,
     detailDir: options.detailDir,
-    claudeMd: options.claudeMd
+    claudeMd: options.claudeMd,
+    rootContent: options.rootContent
   });
 }

--- a/packages/core/src/services/instructions.ts
+++ b/packages/core/src/services/instructions.ts
@@ -198,15 +198,19 @@ export function buildRootContextSection(rootContent?: string): string {
  * Returns the content unchanged when no "Copilot Instructions" heading is present.
  */
 export function normalizeAgentsHeading(content: string, componentName?: string): string {
-  const headingRe = /^#\s+Copilot Instructions(?:\s*:\s*(.*))?\s*$/imu;
-  const match = headingRe.exec(content);
+  // Only consider the first line as the document's top-level heading.
+  const headingRe = /^(?:\uFEFF)?#\s+Copilot Instructions(?:\s*:\s*(.*))?\s*$/iu;
+  const firstLineEnd = content.indexOf("\n");
+  const firstLine = (firstLineEnd === -1 ? content : content.slice(0, firstLineEnd)).trimEnd();
+  const match = headingRe.exec(firstLine);
   if (!match) return content;
 
   const fallback = match[1]?.trim();
   const heading = componentName?.trim() || fallback;
   if (!heading) return content;
 
-  return content.replace(headingRe, `# ${heading}`);
+  const replacedFirstLine = firstLine.replace(headingRe, `# ${heading}`);
+  return firstLineEnd === -1 ? replacedFirstLine : `${replacedFirstLine}\n${content.slice(firstLineEnd + 1)}`;
 }
 
 /**

--- a/packages/core/src/services/instructions.ts
+++ b/packages/core/src/services/instructions.ts
@@ -191,6 +191,25 @@ export function buildRootContextSection(rootContent?: string): string {
 }
 
 /**
+ * Normalize the top-level heading of generated AGENTS.md content so it matches
+ * the file type instead of leaking copilot-instructions.md conventions.
+ * Rewrites "# Copilot Instructions: <name>" → "# <name>" using the provided
+ * component name (area/crate) when available, otherwise the name in the heading.
+ * Returns the content unchanged when no "Copilot Instructions" heading is present.
+ */
+export function normalizeAgentsHeading(content: string, componentName?: string): string {
+  const headingRe = /^#\s+Copilot Instructions(?:\s*:\s*(.*))?\s*$/imu;
+  const match = headingRe.exec(content);
+  if (!match) return content;
+
+  const fallback = match[1]?.trim();
+  const heading = componentName?.trim() || fallback;
+  if (!heading) return content;
+
+  return content.replace(headingRe, `# ${heading}`);
+}
+
+/**
  * Strip outer markdown code fences that LLMs sometimes wrap around generated file content.
  * Only removes a single outer fence (```markdown or bare ```) — internal fences are preserved.
  */
@@ -939,10 +958,15 @@ export async function generateNestedInstructions(
     const basePath = options.area?.path ?? ".";
     const hubRelativePath = path.join(basePath, "AGENTS.md");
 
+    // Normalize the heading so generated AGENTS.md files don't carry a
+    // copilot-instructions.md title (e.g. "# Copilot Instructions: <crate> crate").
+    const componentName = options.area?.name ?? path.basename(options.repoPath);
+    const normalizedHubContent = normalizeAgentsHeading(hubContent, componentName);
+
     // Hub content: prepend frontmatter if area-scoped
-    let finalHubContent = hubContent;
+    let finalHubContent = normalizedHubContent;
     if (options.area) {
-      finalHubContent = `${buildAreaFrontmatter(options.area)}\n\n${hubContent}`;
+      finalHubContent = `${buildAreaFrontmatter(options.area)}\n\n${normalizedHubContent}`;
     }
 
     const result: NestedInstructionsResult = {

--- a/plugin/skills/nested-hub/SKILL.md
+++ b/plugin/skills/nested-hub/SKILL.md
@@ -16,6 +16,27 @@ The hub should contain:
 - Coding conventions and guardrails
 - A "## Detailed Instructions" section listing links to detail files
 
+## Root Context
+
+The prompt may include a `## Root instructions already cover` section containing the workspace-wide content from the root instruction file. That content is already loaded by AI agents from the root file:
+
+- **Do NOT repeat or restate it** — not as prose, not as bullets, not as paraphrased summaries.
+- **Cover only this area/crate's unique details** that are not addressed by the root file.
+- If a topic is covered at the root, reference it with a single link (e.g. `See [AGENTS.md](../../AGENTS.md)`).
+
+## Area / Crate Hubs
+
+When generating a hub for a specific area or crate, include **only crate-unique context**:
+
+- Crate purpose and summary
+- File structure → responsibility mapping
+- Crate-specific conventions (e.g. binary resolution, auth patterns, helper APIs)
+- Internal consumers / dependencies (only if non-obvious)
+
+Everything that applies workspace-wide — workspace dependencies, error types, logging conventions, testing setup, and standard build/test commands — lives exclusively in the root instruction file and must **not** be duplicated here.
+
+Use a simple heading that matches the component, e.g. `# <crate> crate`. Do **not** use a "Copilot Instructions:" heading for AGENTS.md files.
+
 ## Topic Recommendations
 
 At the **end** of your output, emit a fenced JSON block with recommended topics for detail files:
@@ -37,7 +58,7 @@ Recommend 3-5 topics that would benefit from deep-dive detail files. Each slug b
 
 - Keep the hub **lean** — overview and guardrails only, details go in separate files
 - The JSON block will be parsed and removed from the final output
-- Do **not** duplicate content from existing instruction files
+- Do **not** duplicate content from existing instruction files or the root instruction content
 
 ## Output Contract
 

--- a/src/commands/instructions.ts
+++ b/src/commands/instructions.ts
@@ -75,6 +75,10 @@ export async function instructionsCommand(options: InstructionsOptions): Promise
   try {
     const dryRunFiles: { path: string; bytes: number }[] = [];
 
+    // Root instruction content, propagated to per-area generation so area/crate
+    // files don't duplicate what the root file already covers.
+    let rootContent: string | undefined;
+
     // Generate root instructions unless --areas-only
     if (!options.areasOnly && !options.area) {
       if (strategy === "nested") {
@@ -88,6 +92,7 @@ export async function instructionsCommand(options: InstructionsOptions): Promise
             detailDir,
             claudeMd
           });
+          rootContent = nestedResult.hub.content;
           if (options.dryRun) {
             const dryFiles = [
               { path: nestedResult.hub.relativePath, content: nestedResult.hub.content },
@@ -283,7 +288,8 @@ export async function instructionsCommand(options: InstructionsOptions): Promise
               model: options.model,
               onProgress: shouldLog(options) ? (msg) => progress.update(msg) : undefined,
               detailDir,
-              claudeMd
+              claudeMd,
+              rootContent
             });
             if (options.dryRun) {
               const dryFiles = [

--- a/src/services/__tests__/generator.test.ts
+++ b/src/services/__tests__/generator.test.ts
@@ -80,6 +80,39 @@ describe("generateConfigs", () => {
     expect(reviewText).toContain("repo conventions");
   });
 
+  it("references the selected instruction file in vscode settings", async () => {
+    const analysis = makeAnalysis();
+    await generateConfigs({
+      repoPath: tmpDir,
+      analysis,
+      selections: ["vscode"],
+      force: false,
+      instructionFile: "AGENTS.md"
+    });
+
+    const content = await fs.readFile(path.join(tmpDir, ".vscode", "settings.json"), "utf8");
+    const parsed = JSON.parse(content);
+    expect(parsed["github.copilot.chat.codeGeneration.instructions"]).toEqual([
+      { file: "AGENTS.md" }
+    ]);
+  });
+
+  it("defaults vscode settings to .github/copilot-instructions.md", async () => {
+    const analysis = makeAnalysis();
+    await generateConfigs({
+      repoPath: tmpDir,
+      analysis,
+      selections: ["vscode"],
+      force: false
+    });
+
+    const content = await fs.readFile(path.join(tmpDir, ".vscode", "settings.json"), "utf8");
+    const parsed = JSON.parse(content);
+    expect(parsed["github.copilot.chat.codeGeneration.instructions"]).toEqual([
+      { file: ".github/copilot-instructions.md" }
+    ]);
+  });
+
   it("skips existing files without force", async () => {
     await fs.mkdir(path.join(tmpDir, ".vscode"), { recursive: true });
     await fs.writeFile(path.join(tmpDir, ".vscode", "mcp.json"), "original", "utf8");

--- a/src/services/__tests__/instructions.test.ts
+++ b/src/services/__tests__/instructions.test.ts
@@ -9,6 +9,7 @@ import {
   generateAreaInstructions,
   generateCopilotInstructions,
   generateNestedInstructions,
+  generateNestedAreaInstructions,
   writeAreaInstruction,
   writeInstructionFile,
   writeNestedInstructions,
@@ -17,6 +18,8 @@ import {
   areaInstructionPath,
   detectExistingInstructions,
   buildExistingInstructionsSection,
+  buildRootContextSection,
+  normalizeAgentsHeading,
   parseTopicsFromHub,
   stripMarkdownFences
 } from "@agentrc/core/services/instructions";
@@ -431,6 +434,23 @@ describe("buildExistingInstructionsSection", () => {
   });
 });
 
+describe("buildRootContextSection", () => {
+  it("returns empty string when no root content is provided", () => {
+    expect(buildRootContextSection()).toBe("");
+    expect(buildRootContextSection("")).toBe("");
+    expect(buildRootContextSection("   ")).toBe("");
+  });
+
+  it("embeds the root content under a do-not-repeat header", () => {
+    const root = "# Monorepo\n\nWorkspace crates use `{ workspace = true }`.";
+    const section = buildRootContextSection(root);
+    expect(section).toContain("## Root instructions already cover");
+    expect(section).toContain("Do NOT repeat or restate it");
+    expect(section).toContain("# Monorepo");
+    expect(section).toContain("`{ workspace = true }`");
+  });
+});
+
 describe("writeInstructionFile", () => {
   let tmpDir: string;
 
@@ -736,6 +756,29 @@ describe("stripMarkdownFences", () => {
   it("handles empty content", () => {
     expect(stripMarkdownFences("")).toBe("");
     expect(stripMarkdownFences("  ")).toBe("");
+  });
+});
+
+describe("normalizeAgentsHeading", () => {
+  it("returns content unchanged when no Copilot Instructions heading is present", () => {
+    const content = "# git crate\n\nBody.";
+    expect(normalizeAgentsHeading(content, "git")).toBe(content);
+  });
+
+  it("rewrites the heading to the component name", () => {
+    expect(normalizeAgentsHeading("# Copilot Instructions: git crate", "git")).toBe("# git");
+  });
+
+  it("falls back to the name embedded in the heading when no component name", () => {
+    expect(normalizeAgentsHeading("# Copilot Instructions: git crate")).toBe("# git crate");
+  });
+
+  it("matches the heading case-insensitively", () => {
+    expect(normalizeAgentsHeading("# copilot instructions: git crate", "git")).toBe("# git");
+  });
+
+  it("returns content unchanged when heading has no name and no component name", () => {
+    expect(normalizeAgentsHeading("# Copilot Instructions")).toBe("# Copilot Instructions");
   });
 });
 
@@ -1050,5 +1093,43 @@ describe("instruction generation sessions", () => {
         claudeMd: false
       })
     ).rejects.toThrow("Copilot CLI not logged in. Run `copilot` then `/login` to authenticate.");
+  });
+
+  it("propagates root content and normalizes headings for nested area generation", async () => {
+    const area: Area = {
+      name: "git",
+      applyTo: "crates/git/**",
+      path: path.join(tmpDir, "crates", "git"),
+      source: "auto"
+    };
+    const hub = createMockSession();
+    const { createSession } = mockClient([hub.session]);
+    mockSdkTools();
+
+    const rootContent = "# Monorepo\n\nWorkspace crates use `{ workspace = true }`.";
+    let sentPrompt = "";
+
+    hub.session.sendAndWait.mockImplementation(async (args: { prompt: string }) => {
+      sentPrompt = args.prompt;
+      const [config] = createSession.mock.calls[0] as unknown as [
+        { tools: Array<{ handler: Function }> }
+      ];
+      await config.tools[0].handler({
+        content: "```markdown\n# Copilot Instructions: git crate\n\nCrate-specific.\n```"
+      });
+    });
+
+    const result = await generateNestedAreaInstructions({
+      repoPath: tmpDir,
+      area,
+      detailDir: ".agents",
+      claudeMd: false,
+      rootContent
+    });
+
+    expect(result.hub.content).toContain("# git");
+    expect(result.hub.content).not.toContain("Copilot Instructions");
+    expect(sentPrompt).toContain("## Root instructions already cover");
+    expect(sentPrompt).toContain("Workspace crates use `{ workspace = true }`");
   });
 });


### PR DESCRIPTION
## Summary

Fixes #45. When `agentrc instructions` generates nested instruction files for a
large monorepo (e.g. a Rust workspace with 24+ crates), the per-crate
`AGENTS.md` files no longer duplicate the workspace-wide root instructions, drop
the misleading `# Copilot Instructions: <crate> crate` heading, and now know what
the root file already covers so the LLM only emits crate-unique context.

## Approach

The content of these files is LLM-generated from skills (see
`plugin/skills/nested-hub/SKILL.md`, `plugin/skills/nested-detail/SKILL.md`), so
deduplication is done at *generation time*: after the root `AGENTS.md` hub is
generated, its content is fed back into the per-area / per-crate generation
prompts as a "Root instructions already cover" section, and the skill prompt
explicitly instructs the model to only cover crate-unique details and never
repeat the root file. A deterministic post-processing step normalizes the
top-level heading.

## Changes (per issue findings)

| Finding | Addressed by |
| --- | --- |
| **F2 "Kitchen sink"** – per-crate files repeated root conventions (`{ workspace = true }`, error types, logging, testing, build commands) | Root hub content is threaded into nested generation (`rootContent` on the generation options), embedded in the prompt via `buildRootContextSection()` (`## Root instructions already cover … Do NOT repeat or restate it`), and the `nested-hub` skill instructs crate-unique-only output. |
| **F3 Redundant "Monorepo Context"** section | Covered by the same root-context injection; the `nested-hub` skill drops the crate-unique-only rule and the root-context section, so workspace-wide facts live only in the root file. |
| **F4 Title mismatch** – `# Copilot Instructions: <crate> crate` heading on AGENTS.md | `normalizeAgentsHeading()` rewrites the heading to `# <crate>` (falling back to the name in the heading) for all nested AGENTS.md output. |
| **F1 Dual file types** | The generator now honors a configurable `instructionFile` (default unchanged: `.github/copilot-instructions.md`), so a repo can consistently reference a single instruction file in VS Code settings. Choosing one strategy per repo remains an explicit `agentrc instructions --strategy` decision. |

## Commit history (branch `feature/deduplicate-agents-md`, base `8d0c05c`)

```
734e812 refactor(instructions): prepare nested generation context
8e98a35 feat(skills): reduce duplicated workspace instructions
775d426 feat(instructions): normalize AGENTS headings
f1aa05b fix(generator): respect selected instruction output
7a19fd7 refactor(cli): propagate nested generation context
f702d50 test(instructions): cover nested AGENTS generation
```

## Files changed

```
packages/core/src/services/instructions.ts   root-context plumbing + heading normalization
packages/core/src/services/generator.ts      configurable instructionFile in VS Code settings
plugin/skills/nested-hub/SKILL.md            crate-unique-only + root-context guidance
src/commands/instructions.ts                 CLI wiring of root content into area generation
src/services/__tests__/instructions.test.ts  +8 tests (buildRootContextSection, normalizeAgentsHeading, integration)
src/services/__tests__/generator.test.ts     +2 tests (instructionFile honored / default)
```

Net: +213 / −14 across 6 files.

## Verification

- `npm run lint`, `npm run typecheck`, `npm test` all green (685 tests across 31 files, +10 new).
- Existing behavior preserved when `rootContent` is unset (`--areas-only`, single `--area`, flat strategy) — falls back to the previous prompt.

## Confidence

High for **F2/F3/F4** (~90%): heading normalization is deterministic, and the
root-context prompt section + skill guidance directly target the observed
duplication. Note the dedup itself is prompt-driven (LLM), so output varies per
model run — the deterministic fallback (`buildExistingInstructionsSection`
"do not restate it" rule) remains as a safety net.

Partial for **F1** (~70%): the generator can now reference a single instruction
file, but enforcing a single strategy per repo (root AGENTS.md + per-directory
vs. copilot-instructions.md + `.github/instructions/*.instructions.md` globs)
and the *post-generation dedup pass* listed under "Suggested improvements" are
not implemented and can be follow-ups.

## Follow-ups (out of scope here)

- Wire `instructionFile` through `init`/`pr`/`generate` CLI + VS Code extension callers (currently API-available, callers keep the default).
- Optional post-generation dedup pass that diffs generated files against the root and warns on detected duplication.
