### PR TITLE
fix(vscode): batch instructions honors nested strategy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ All notable changes to this project will be documented in this file.
 
 ### Bug Fixes
 
+- **Batch Instructions honors nested strategy** — the VS Code "Batch Instructions" command now generates hub + detail files (`.agents/*.md`, optional `CLAUDE.md`) for repositories configured with `strategy: "nested"` instead of a single flat `AGENTS.md` (#58)
+
 - **Config scaffolding for simple repos** — `agentrc init` and the TUI now create `agentrc.config.json` even when no areas are detected, producing a minimal `{}` stub. Previously failed with "No areas detected. Cannot scaffold agentrc.config.json."
 
 ## [2.1.0]

--- a/vscode-extension/src/commands/batch.ts
+++ b/vscode-extension/src/commands/batch.ts
@@ -1,5 +1,11 @@
 import * as vscode from "vscode";
-import { generateCopilotInstructions, loadAgentrcConfig, safeWriteFile } from "../services.js";
+import {
+  generateCopilotInstructions,
+  generateNestedInstructions,
+  loadAgentrcConfig,
+  safeWriteFile,
+  writeNestedInstructions
+} from "../services.js";
 import { VscodeProgressReporter } from "../progress.js";
 import path from "node:path";
 
@@ -34,35 +40,55 @@ export async function batchInstructionsCommand(): Promise<void> {
         const workspacePath = folder.uri.fsPath;
         const name = folder.name;
         try {
-          let outputPath = path.join(workspacePath, ".github", "copilot-instructions.md");
-          try {
-            const config = await loadAgentrcConfig(workspacePath);
-            if (config?.strategy === "nested") {
-              outputPath = path.join(workspacePath, "AGENTS.md");
+          const config = await loadAgentrcConfig(workspacePath).catch(() => undefined);
+
+          if (config?.strategy === "nested") {
+            const detailDir = config.detailDir ?? ".agents";
+            const claudeMd = config.claudeMd ?? false;
+
+            reporter.update(`[${name}] Generating nested instructions…`);
+            const nestedResult = await generateNestedInstructions({
+              repoPath: workspacePath,
+              model,
+              onProgress: (msg) => reporter.update(msg),
+              detailDir,
+              claudeMd
+            });
+
+            const actions = await writeNestedInstructions(workspacePath, nestedResult, false);
+            if (actions.some((a) => a.action === "wrote")) {
+              wrote++;
+            } else {
+              skipped++;
+              reporter.update(`[${name}] Skipped: instruction files already exist`);
             }
-          } catch {
-            // Non-fatal
-          }
 
-          reporter.update(`[${name}] Generating…`);
-          const content = await generateCopilotInstructions({
-            repoPath: workspacePath,
-            model
-          });
-
-          if (!content) {
-            skipped++;
-            continue;
-          }
-
-          const { wrote: didWrite, reason } = await safeWriteFile(outputPath, content, false);
-          if (didWrite) {
-            wrote++;
+            for (const warning of nestedResult.warnings) {
+              reporter.update(`Warning: ${warning}`);
+            }
           } else {
-            skipped++;
-            reporter.update(
-              `[${name}] Skipped: ${reason === "exists" ? "file already exists" : (reason ?? "unknown")}`
-            );
+            const outputPath = path.join(workspacePath, ".github", "copilot-instructions.md");
+
+            reporter.update(`[${name}] Generating…`);
+            const content = await generateCopilotInstructions({
+              repoPath: workspacePath,
+              model
+            });
+
+            if (!content) {
+              skipped++;
+              continue;
+            }
+
+            const { wrote: didWrite, reason } = await safeWriteFile(outputPath, content, false);
+            if (didWrite) {
+              wrote++;
+            } else {
+              skipped++;
+              reporter.update(
+                `[${name}] Skipped: ${reason === "exists" ? "file already exists" : (reason ?? "unknown")}`
+              );
+            }
           }
         } catch (err) {
           failed++;

--- a/vscode-extension/src/commands/batch.ts
+++ b/vscode-extension/src/commands/batch.ts
@@ -60,7 +60,9 @@ export async function batchInstructionsCommand(): Promise<void> {
               wrote++;
             } else {
               skipped++;
-              reporter.update(`[${name}] Skipped: instruction files already exist`);
+              reporter.update(
+                `[${name}] Skipped: no files written (${Array.from(new Set(actions.map((a) => a.action))).join(", ")})`
+              );
             }
 
             for (const warning of nestedResult.warnings) {


### PR DESCRIPTION
## Summary

Fixes #58. The VS Code **Batch Instructions** command (`agentrc.batchInstructions`) now honors `strategy: "nested"` in `agentrc.config.json`. Previously it only swapped the output filename to `AGENTS.md` while still calling the flat generation API, so nested repositories received a single flat file instead of the hub + detail structure.

## What changed

`vscode-extension/src/commands/batch.ts` — the per-root loop now branches on strategy:

- **Nested** (`config.strategy === "nested"`):
  - Resolves `detailDir = config.detailDir ?? ".agents"` and `claudeMd = config.claudeMd ?? false`.
  - Calls `generateNestedInstructions({ repoPath, model, onProgress, detailDir, claudeMd })`.
  - Persists via `writeNestedInstructions(workspacePath, result, false)` — writes `AGENTS.md`, `.agents/{slug}.md`, and optional `CLAUDE.md`.
  - Counts wrote/skipped per root from the returned `FileAction[]` and forwards `result.warnings` to progress.
- **Flat**: the existing `generateCopilotInstructions` + `safeWriteFile` implementation is unchanged.

The nested branch mirrors the already-shipped single-root command (`vscode-extension/src/commands/instructions.ts`), reusing the same exported core services and configuration defaults. No changes to `packages/core`, the CLI, or any APIs.

## Behavior preserved

- Skip-if-exists: `writeNestedInstructions(..., false)` delegates to the same `safeWriteFile` guard used by the flat path.
- Progress reporting and `wrote` / `skipped` / `failed` per-root counters and the final `Done: … (N roots)` message.
- Non-fatal config loading (missing/malformed `agentrc.config.json` falls back to flat).
- Flat repositories behave exactly as before.

## Verification

- `npm run lint` — clean
- `npm run typecheck` — clean
- `npm test` — 675 passed (31 files)
- Extension: `npx eslint .` — clean; `npx tsc --noEmit` introduces no new errors; `npx prettier --check` — clean

## Files changed

```
vscode-extension/src/commands/batch.ts   strategy branch (nested vs flat)
CHANGELOG.md                             Bug Fix entry
```
